### PR TITLE
fix(auth): pass OAuth user key to OpenRouter models endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ bun start             # Start both client (port 3000) and proxy server (port 300
 bun run start:client  # Start Vite dev server only
 bun run start:server  # Start Bun proxy server only
 bun run build         # Production build (output to build/)
-bun test              # Run tests with Vitest
+bun run test          # Run tests with Vitest (not `bun test` which uses Bun's native runner)
 bun run typecheck     # TypeScript type checking
 bun run lint          # Run Biome linter
 bun run lint:fix      # Fix linting issues automatically

--- a/server/index.ts
+++ b/server/index.ts
@@ -247,20 +247,25 @@ Bun.serve({
                 );
             }
 
-            if (!OPENROUTER_API_KEY) {
+            // Use client-provided OAuth key (via Authorization header) or fall back to server env var
+            const authHeader = req.headers.get("authorization");
+            const userKey = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+            const apiKey = userKey || OPENROUTER_API_KEY;
+
+            if (!apiKey) {
                 return new Response(
-                    JSON.stringify({ error: "OPENROUTER_API_KEY environment variable not set on server" }),
-                    { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+                    JSON.stringify({ error: "No API key available. Please log in with OpenRouter or set OPENROUTER_API_KEY." }),
+                    { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
                 );
             }
 
             try {
-                console.log("[OpenRouter] Fetching user models");
+                console.log(`[OpenRouter] Fetching user models (source: ${userKey ? "user OAuth" : "server key"})`);
 
                 const response = await fetch("https://openrouter.ai/api/v1/models/user", {
                     method: "GET",
                     headers: {
-                        "Authorization": `Bearer ${OPENROUTER_API_KEY}`,
+                        "Authorization": `Bearer ${apiKey}`,
                         "Content-Type": "application/json",
                         "HTTP-Referer": "https://github.com/jessearmand/latent-space-generator",
                         "X-Title": "latent-space-generator",

--- a/src/components/PromptOptimizer.tsx
+++ b/src/components/PromptOptimizer.tsx
@@ -169,7 +169,9 @@ export const PromptOptimizer: React.FC<PromptOptimizerProps> = ({
     );
 
     const hasApiKeyError =
+        modelsError?.includes("API key") ||
         modelsError?.includes("OPENROUTER_API_KEY") ||
+        (completionError as Error | undefined)?.message?.includes("API key") ||
         (completionError as Error | undefined)?.message?.includes("OPENROUTER_API_KEY");
 
     return (
@@ -190,8 +192,9 @@ export const PromptOptimizer: React.FC<PromptOptimizerProps> = ({
                 <div className="prompt-optimizer-content">
                     {hasApiKeyError ? (
                         <div className="no-api-key-message">
-                            OpenRouter API key not configured. Set OPENROUTER_API_KEY
-                            environment variable on the server.
+                            OpenRouter API key not configured. Log in with OpenRouter
+                            in Settings, or set OPENROUTER_API_KEY environment variable
+                            on the server.
                         </div>
                     ) : (
                         <>

--- a/src/contexts/OpenRouterContext.tsx
+++ b/src/contexts/OpenRouterContext.tsx
@@ -22,6 +22,7 @@ import {
     getOpenRouterModels,
     clearOpenRouterModelsCache,
 } from "../services/openrouter";
+import { useOpenRouterAuth } from "./OpenRouterAuthContext";
 
 interface OpenRouterContextType {
     /** All available models */
@@ -57,6 +58,7 @@ const SELECTED_MODEL_KEY = "openrouter_selected_model";
 const FILTERS_KEY = "openrouter_model_filters";
 
 export const OpenRouterProvider: React.FC<OpenRouterProviderProps> = ({ children }) => {
+    const { userApiKey } = useOpenRouterAuth();
     const [models, setModels] = useState<OpenRouterModel[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -163,7 +165,7 @@ export const OpenRouterProvider: React.FC<OpenRouterProviderProps> = ({ children
                 }
 
                 // Fetch from API (with caching handled by service)
-                const fetchedModels = await getOpenRouterModels(forceRefresh);
+                const fetchedModels = await getOpenRouterModels(forceRefresh, userApiKey);
 
                 if (fetchedModels.length === 0) {
                     setError("No models available");
@@ -179,7 +181,7 @@ export const OpenRouterProvider: React.FC<OpenRouterProviderProps> = ({ children
                 setIsLoading(false);
             }
         },
-        [restoreSelectedModel]
+        [restoreSelectedModel, userApiKey]
     );
 
     // Initial load on mount

--- a/src/services/openrouter.ts
+++ b/src/services/openrouter.ts
@@ -8,12 +8,17 @@ import type { OpenRouterModel, OpenRouterModelsResponse } from "../types/openrou
 const PROXY_URL = "http://localhost:3001/api/openrouter/models";
 
 /** Fetch models from OpenRouter API via proxy */
-export async function fetchOpenRouterModels(): Promise<OpenRouterModel[]> {
+export async function fetchOpenRouterModels(userApiKey?: string | null): Promise<OpenRouterModel[]> {
+    const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+    };
+    if (userApiKey) {
+        headers.Authorization = `Bearer ${userApiKey}`;
+    }
+
     const response = await fetch(PROXY_URL, {
         method: "GET",
-        headers: {
-            "Content-Type": "application/json",
-        },
+        headers,
     });
 
     if (!response.ok) {
@@ -76,7 +81,7 @@ export function clearOpenRouterModelsCache(): void {
  * Get models with caching
  * Tries cache first, then fetches from API
  */
-export async function getOpenRouterModels(forceRefresh = false): Promise<OpenRouterModel[]> {
+export async function getOpenRouterModels(forceRefresh = false, userApiKey?: string | null): Promise<OpenRouterModel[]> {
     // Try cache first unless forcing refresh
     if (!forceRefresh) {
         const cached = getCachedOpenRouterModels();
@@ -86,7 +91,7 @@ export async function getOpenRouterModels(forceRefresh = false): Promise<OpenRou
     }
 
     // Fetch from API
-    const models = await fetchOpenRouterModels();
+    const models = await fetchOpenRouterModels(userApiKey);
 
     // Cache the results
     cacheOpenRouterModels(models);


### PR DESCRIPTION
The /api/openrouter/models endpoint was the only OpenRouter endpoint that didn't accept user OAuth keys, causing "API key not configured" errors after page refresh when no server OPENROUTER_API_KEY was set.