### PR TITLE
build(lint): migrate lint workflow to oxlint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "./node_modules/oxlint/configuration_schema.json",
+    "plugins": ["eslint", "typescript", "unicorn", "oxc", "react", "jsx-a11y", "import", "vitest"],
+    "categories": {
+        "correctness": "error",
+        "suspicious": "warn"
+    },
+    "rules": {
+        "import/no-unassigned-import": "off",
+        "react/react-in-jsx-scope": "off",
+        "unicorn/consistent-function-scoping": "off",
+        "unicorn/no-array-sort": "off"
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Latent Space Generator — React single-page application for AI media generation
 - **OpenAI models**: GPT Image models (gpt-image-1.5, gpt-image-1-mini) via direct API calls, fal.ai, or OpenRouter
 - **Gemini image models**: Gemini 2.5 Flash Image, Gemini 3 Pro Image via fal.ai (OpenRouter fallback)
 
-Uses Vite for development, Vitest for testing, and Biome for linting.
+Uses Vite for development, Vitest for testing, and Oxlint for linting. Biome is temporarily retained during the migration for parity checks.
 
 ## Development Commands
 
@@ -23,8 +23,9 @@ bun run start:server  # Start Bun proxy server only
 bun run build         # Production build (output to build/)
 bun run test          # Run tests with Vitest (not `bun test` which uses Bun's native runner)
 bun run typecheck     # TypeScript type checking
-bun run lint          # Run Biome linter
-bun run lint:fix      # Fix linting issues automatically
+bun run lint          # Run Oxlint and fail on warnings
+bun run lint:fix      # Apply Oxlint autofixes, then fail on remaining warnings
+bun run lint:biome    # Temporary parity check during the Biome -> Oxlint migration
 ```
 
 ## Architecture

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "@vitejs/plugin-react": "^5.1.2",
         "concurrently": "^9.1.0",
         "jsdom": "^27.3.0",
+        "oxlint": "^1.55.0",
         "typescript": "^5.7",
         "vite": "^7.3.0",
         "vitest": "^4.0.16",
@@ -195,6 +196,44 @@
     "@openrouter/sdk": ["@openrouter/sdk@0.1.27", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RH//L10bSmc81q25zAZudiI4kNkLgxF2E+WU42vghp3N6TEvZ6F0jK7uT3tOxkEn91gzmMw9YVmDENy7SJsajQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.55.0", "", { "os": "android", "cpu": "arm" }, "sha512-NhvgAhncTSOhRahQSCnkK/4YIGPjTmhPurQQ2dwt2IvwCMTvZRW5vF2K10UBOxFve4GZDMw6LtXZdC2qeuYIVQ=="],
+
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.55.0", "", { "os": "android", "cpu": "arm64" }, "sha512-P9iWRh+Ugqhg+D7rkc7boHX8o3H2h7YPcZHQIgvVBgnua5tk4LR2L+IBlreZs58/95cd2x3/004p5VsQM9z4SA=="],
+
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.55.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-esakkJIt7WFAhT30P/Qzn96ehFpzdZ1mNuzpOb8SCW7lI4oB8VsyQnkSHREM671jfpuBb/o2ppzBCx5l0jpgMA=="],
+
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.55.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-xDMFRCCAEK9fOH6As2z8ELsC+VDGSFRHwIKVSilw+xhgLwTDFu37rtmRbmUlx8rRGS6cWKQPTc47AVxAZEVVPQ=="],
+
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.55.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-mYZqnwUD7ALCRxGenyLd1uuG+rHCL+OTT6S8FcAbVm/ZT2AZMGjvibp3F6k1SKOb2aeqFATmwRykrE41Q0GWVw=="],
+
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.55.0", "", { "os": "linux", "cpu": "arm" }, "sha512-LcX6RYcF9vL9ESGwJW3yyIZ/d/ouzdOKXxCdey1q0XJOW1asrHsIg5MmyKdEBR4plQx+shvYeQne7AzW5f3T1w=="],
+
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.55.0", "", { "os": "linux", "cpu": "arm" }, "sha512-C+8GS1rPtK+dI7mJFkqoRBkDuqbrNihnyYQsJPS9ez+8zF9JzfvU19lawqt4l/Y23o5uQswE/DORa8aiXUih3w=="],
+
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.55.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-ErLE4XbmcCopA4/CIDiH6J1IAaDOMnf/KSx/aFObs4/OjAAM3sFKWGZ57pNOMxhhyBdcmcXwYymph9GwcpcqgQ=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.55.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/kp65avi6zZfqEng56TTuhiy3P/3pgklKIdf38yvYeJ9/PgEeRA2A2AqKAKbZBNAqUzrzHhz9jF6j/PZvhJzTQ=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.55.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-A6pTdXwcEEwL/nmz0eUJ6WxmxcoIS+97GbH96gikAyre3s5deC7sts38ZVVowjS2QQFuSWkpA4ZmQC0jZSNvJQ=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.55.0", "", { "os": "linux", "cpu": "none" }, "sha512-clj0lnIN+V52G9tdtZl0LbdTSurnZ1NZj92Je5X4lC7gP5jiCSW+Y/oiDiSauBAD4wrHt2S7nN3pA0zfKYK/6Q=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.55.0", "", { "os": "linux", "cpu": "none" }, "sha512-NNu08pllN5x/O94/sgR3DA8lbrGBnTHsINZZR0hcav1sj79ksTiKKm1mRzvZvacwQ0hUnGinFo+JO75ok2PxYg=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.55.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-BvfQz3PRlWZRoEZ17dZCqgQsMRdpzGZomJkVATwCIGhHVVeHJMQdmdXPSjcT1DCNUrOjXnVyj1RGDj5+/Je2+Q=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.55.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ngSOoFCSBMKVQd24H8zkbcBNc7EHhjnF1sv3mC9NNXQ/4rRjI/4Dj9+9XoDZeFEkF1SX1COSBXF1b2Pr9rqdEw=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.55.0", "", { "os": "linux", "cpu": "x64" }, "sha512-BDpP7W8GlaG7BR6QjGZAleYzxoyKc/D24spZIF2mB3XsfALQJJT/OBmP8YpeTb1rveFSBHzl8T7l0aqwkWNdGA=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.55.0", "", { "os": "none", "cpu": "arm64" }, "sha512-PS6GFvmde/pc3fCA2Srt51glr8Lcxhpf6WIBFfLphndjRrD34NEcses4TSxQrEcxYo6qVywGfylM0ZhSCF2gGA=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.55.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-P6JcLJGs/q1UOvDLzN8otd9JsH4tsuuPDv+p7aHqHM3PrKmYdmUvkNj4K327PTd35AYcznOCN+l4ZOaq76QzSw=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.55.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-gzkk4zE2zsE+WmRxFOiAZHpCpUNDFytEakqNXoNHW+PnYEOTPKDdW6nrzgSeTbGKVPXNAKQnRnMgrh7+n3Xueg=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.55.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ZFALNow2/og75gvYzNP7qe+rREQ5xunktwA+lgykoozHZ6hw9bqg4fn5j2UvG4gIn1FXqrZHkOAXuPf5+GOYTQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.53", "", {}, "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ=="],
 
@@ -409,6 +448,8 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "oxlint": ["oxlint@1.55.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.55.0", "@oxlint/binding-android-arm64": "1.55.0", "@oxlint/binding-darwin-arm64": "1.55.0", "@oxlint/binding-darwin-x64": "1.55.0", "@oxlint/binding-freebsd-x64": "1.55.0", "@oxlint/binding-linux-arm-gnueabihf": "1.55.0", "@oxlint/binding-linux-arm-musleabihf": "1.55.0", "@oxlint/binding-linux-arm64-gnu": "1.55.0", "@oxlint/binding-linux-arm64-musl": "1.55.0", "@oxlint/binding-linux-ppc64-gnu": "1.55.0", "@oxlint/binding-linux-riscv64-gnu": "1.55.0", "@oxlint/binding-linux-riscv64-musl": "1.55.0", "@oxlint/binding-linux-s390x-gnu": "1.55.0", "@oxlint/binding-linux-x64-gnu": "1.55.0", "@oxlint/binding-linux-x64-musl": "1.55.0", "@oxlint/binding-openharmony-arm64": "1.55.0", "@oxlint/binding-win32-arm64-msvc": "1.55.0", "@oxlint/binding-win32-ia32-msvc": "1.55.0", "@oxlint/binding-win32-x64-msvc": "1.55.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.15.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-T+FjepiyWpaZMhekqRpH8Z3I4vNM610p6w+Vjfqgj5TZUxHXl7N8N5IPvmOU8U4XdTRxqtNNTh9Y4hLtr7yvFg=="],
 
     "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "preview": "vite preview",
     "test": "vitest",
     "typecheck": "tsc -b",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint --write .",
+    "lint": "oxlint . --deny-warnings --report-unused-disable-directives-severity=error",
+    "lint:fix": "oxlint . --fix --deny-warnings --report-unused-disable-directives-severity=error",
+    "lint:biome": "biome lint .",
     "shutdown": "./scripts/shutdown.sh"
   },
   "browserslist": {
@@ -47,6 +48,7 @@
     "@vitejs/plugin-react": "^5.1.2",
     "concurrently": "^9.1.0",
     "jsdom": "^27.3.0",
+    "oxlint": "^1.55.0",
     "typescript": "^5.7",
     "vite": "^7.3.0",
     "vitest": "^4.0.16"

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -75,7 +75,7 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({ src, title = 'Generate
                 <DownloadButton url={src} label="Download audio" />
             </div>
 
-            {/* biome-ignore lint/a11y/useMediaCaption: Generated audio, no captions available */}
+            {/* oxlint-disable-next-line jsx-a11y/media-has-caption -- Generated audio files do not include caption tracks. */}
             <audio
                 ref={audioRef}
                 src={src}

--- a/src/components/AudioUploadZone.tsx
+++ b/src/components/AudioUploadZone.tsx
@@ -4,7 +4,7 @@
  */
 
 import type React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import './AudioUploadZone.css';
 
 interface AudioUploadZoneProps {
@@ -24,6 +24,7 @@ export const AudioUploadZone: React.FC<AudioUploadZoneProps> = ({
     const [isDragging, setIsDragging] = useState(false);
     const [audioPreviewUrl, setAudioPreviewUrl] = useState<string | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const inputId = useId();
 
     // Revoke object URL on unmount to prevent memory leaks
     useEffect(() => {
@@ -116,8 +117,7 @@ export const AudioUploadZone: React.FC<AudioUploadZoneProps> = ({
 
     return (
         <div className="audio-upload-zone-container">
-            {/* biome-ignore lint/a11y/noLabelWithoutControl: Associated with hidden file input */}
-            <label className="audio-upload-label">Upload Audio File:</label>
+            <label htmlFor={inputId} className="audio-upload-label">Upload Audio File:</label>
 
             {!uploadedFile ? (
                 <button
@@ -150,7 +150,7 @@ export const AudioUploadZone: React.FC<AudioUploadZoneProps> = ({
                         </span>
                     </div>
                     {audioPreviewUrl && (
-                        /* biome-ignore lint/a11y/useMediaCaption: Uploaded audio, no captions available */
+                        /* oxlint-disable-next-line jsx-a11y/media-has-caption -- Uploaded previews do not ship with caption tracks. */
                         <audio
                             src={audioPreviewUrl}
                             controls
@@ -169,6 +169,7 @@ export const AudioUploadZone: React.FC<AudioUploadZoneProps> = ({
             )}
 
             <input
+                id={inputId}
                 ref={fileInputRef}
                 type="file"
                 accept={ACCEPTED_EXTENSIONS.join(',')}

--- a/src/components/HistoryImageCard.tsx
+++ b/src/components/HistoryImageCard.tsx
@@ -38,7 +38,7 @@ export const HistoryImageCard: React.FC<HistoryImageCardProps> = ({ entry, onRem
 
     return (
         <>
-            {/* biome-ignore lint/a11y/useSemanticElements: button wraps complex card layout with nested interactive elements */}
+            {/* oxlint-disable jsx-a11y/prefer-tag-over-role -- This preview container includes nested action buttons, so a semantic button wrapper would create invalid interactive nesting. */}
             <div
                 className="history-image-card"
                 onClick={handleClick}
@@ -71,6 +71,7 @@ export const HistoryImageCard: React.FC<HistoryImageCardProps> = ({ entry, onRem
                     timestamp={entry.timestamp}
                 />
             </div>
+            {/* oxlint-enable jsx-a11y/prefer-tag-over-role */}
 
             <ImagePreviewModal
                 isOpen={isPreviewOpen}

--- a/src/components/HistoryVideoCard.css
+++ b/src/components/HistoryVideoCard.css
@@ -17,6 +17,11 @@
 .history-video-thumb {
     position: relative;
     aspect-ratio: 16/9;
+    display: block;
+    width: 100%;
+    padding: 0;
+    border: 0;
+    background: transparent;
 }
 
 .history-video-thumb video {

--- a/src/components/HistoryVideoCard.tsx
+++ b/src/components/HistoryVideoCard.tsx
@@ -44,20 +44,17 @@ export const HistoryVideoCard: React.FC<HistoryVideoCardProps> = ({ entry, onRem
                     </button>
                 </div>
             ) : (
-                // biome-ignore lint/a11y/useSemanticElements: div wraps video thumbnail with complex layout
-                <div
+                <button
+                    type="button"
                     className="history-video-thumb"
                     onClick={handleToggle}
-                    role="button"
-                    tabIndex={0}
-                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleToggle(); } }}
                     aria-label={`Play video: ${entry.prompt || 'Generated video'}`}
                 >
                     <video src={videoUrl} preload="metadata" muted>
                         <track kind="captions" />
                     </video>
                     <span className="history-video-play-icon" aria-hidden="true" />
-                </div>
+                </button>
             )}
 
             <div className="history-card-actions">

--- a/src/components/ImageUploadZone.tsx
+++ b/src/components/ImageUploadZone.tsx
@@ -268,7 +268,7 @@ export const ImageUploadZone: React.FC<ImageUploadZoneProps> = ({
                 </button>
             )}
 
-            {/* biome-ignore lint/a11y/useSemanticElements: Drop zone requires div for drag-and-drop functionality */}
+            {/* oxlint-disable jsx-a11y/prefer-tag-over-role -- The drop zone needs drag-and-drop behavior and contains nested controls, so a semantic button wrapper would be invalid. */}
             <div
                 className={zoneClasses}
                 onDragOver={handleDragOver}
@@ -330,6 +330,7 @@ export const ImageUploadZone: React.FC<ImageUploadZoneProps> = ({
                     </div>
                 )}
             </div>
+            {/* oxlint-enable jsx-a11y/prefer-tag-over-role */}
 
             {error && <p className="upload-error">{error}</p>}
         </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -358,7 +358,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                         </button>
 
                         {isExpanded && (
-                            // biome-ignore lint/a11y/useSemanticElements: WAI-ARIA TreeView requires role="group" for child grouping
                             <div
                                 role="group"
                                 className="sidebar-mode-list"

--- a/src/components/VideoUploadZone.tsx
+++ b/src/components/VideoUploadZone.tsx
@@ -4,7 +4,7 @@
  */
 
 import type React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import './VideoUploadZone.css';
 
 interface VideoUploadZoneProps {
@@ -24,6 +24,7 @@ export const VideoUploadZone: React.FC<VideoUploadZoneProps> = ({
     const [isDragging, setIsDragging] = useState(false);
     const [videoPreviewUrl, setVideoPreviewUrl] = useState<string | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const inputId = useId();
 
     // Sync preview URL when parent clears the file externally
     useEffect(() => {
@@ -124,8 +125,7 @@ export const VideoUploadZone: React.FC<VideoUploadZoneProps> = ({
 
     return (
         <div className="video-upload-zone-container">
-            {/* biome-ignore lint/a11y/noLabelWithoutControl: Associated with hidden file input */}
-            <label className="video-upload-label">Upload Video File:</label>
+            <label htmlFor={inputId} className="video-upload-label">Upload Video File:</label>
 
             {!uploadedFile ? (
                 <button
@@ -158,7 +158,7 @@ export const VideoUploadZone: React.FC<VideoUploadZoneProps> = ({
                         </span>
                     </div>
                     {videoPreviewUrl && (
-                        /* biome-ignore lint/a11y/useMediaCaption: Uploaded video, no captions available */
+                        /* oxlint-disable-next-line jsx-a11y/media-has-caption -- Uploaded previews do not ship with caption tracks. */
                         <video
                             src={videoPreviewUrl}
                             controls
@@ -177,6 +177,7 @@ export const VideoUploadZone: React.FC<VideoUploadZoneProps> = ({
             )}
 
             <input
+                id={inputId}
                 ref={fileInputRef}
                 type="file"
                 accept={ACCEPTED_EXTENSIONS.join(',')}

--- a/src/utils/logSanitizer.ts
+++ b/src/utils/logSanitizer.ts
@@ -6,11 +6,12 @@
  * from `\x1b[A` (ANSI cursor-up escape code) used by progress
  * libraries like tqdm.
  */
-// Regex patterns to match control characters - these are intentional
-// biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally matching ANSI escape sequences
-const ANSI_ESCAPE_REGEX = /\x1b\[[0-9;]*[A-Za-z]/g;
-// biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally matching control characters
-const CONTROL_CHAR_REGEX = /[\x00-\x08\x0b\x0c\x0e-\x1f]/g;
+// Regex patterns to match ANSI and control characters.
+// Unicode escapes preserve intent without embedding raw control characters.
+// oxlint-disable-next-line no-control-regex -- This regex intentionally matches ANSI escape prefixes from external progress output.
+const ANSI_ESCAPE_REGEX = /\u001B\[[0-9;]*[A-Za-z]/g;
+// oxlint-disable-next-line no-control-regex -- This regex intentionally strips ASCII control characters except newlines.
+const CONTROL_CHAR_REGEX = /[\u0000-\u0008\u000B\u000C\u000E-\u001F]/g;
 
 export function sanitizeLogMessage(message: string): string {
     if (!message) return 'Processing...';


### PR DESCRIPTION
Switch the repo's primary lint scripts from Biome to Oxlint and add a repo-scoped .oxlintrc configuration for the current React/TypeScript surface area.

Translate the existing Biome suppressions into explicit Oxlint decisions: fix label associations in upload zones, convert the video history trigger into a semantic button, and keep narrowly scoped disables where the UI or log-sanitizing regexes are intentionally exceptional.

Keep Biome available as a temporary parity script while the migration is in progress, and update contributor docs to reflect the new lint entry points.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured Oxlint with enhanced rule sets for comprehensive code quality checks.

* **Bug Fixes**
  * Improved form accessibility by properly associating labels with input fields.
  * Enhanced semantic HTML structure for interactive elements.

* **Chores**
  * Migrated linting infrastructure from Biome to Oxlint.
  * Updated lint directives and CSS refinements across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->