### PR TITLE
feat(video): add extend-video mode with LTX 2.3 Pro and FLUX 3/Draft

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -51,6 +51,16 @@ label {
   resize: vertical;
 }
 
+.prompt-required-mark {
+  color: #dc3545;
+}
+
+.prompt-optional-hint {
+  font-size: 0.85em;
+  color: #666;
+  margin-top: -4px;
+}
+
 .generate-btn {
   padding: 12px 20px;
   font-size: 1em;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -287,6 +287,8 @@ const AppContent: React.FC = () => {
                                 {activeTab === 'video-to-video' && 'Upload a video and enter a prompt to transform it.'}
                                 {activeTab === 'reference-to-video' &&
                                     'Upload up to 9 reference images and use @Image1, @Image2... in your prompt.'}
+                                {activeTab === 'extend-video' &&
+                                    'Upload a clip and continue it past its final frame. The highlighted band shows how far this model can extend it.'}
                                 {activeTab === 'text-to-speech' && 'Enter text to convert to speech.'}
                                 {activeTab === 'text-to-audio' && 'Enter a prompt to generate music or sound effects.'}
                                 {activeTab === 'audio-to-audio' &&

--- a/src/components/ExtendTimeline.css
+++ b/src/components/ExtendTimeline.css
@@ -1,0 +1,199 @@
+/* Extend-video timeline: source strip + hatched extension band */
+
+.extend-timeline {
+  margin-bottom: 4px;
+}
+
+.extend-timeline-ticks {
+  position: relative;
+  height: 18px;
+  margin-bottom: 4px;
+}
+
+.extend-timeline-tick {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.extend-timeline-tick-label {
+  font-size: 0.65em;
+  color: #999;
+  font-variant-numeric: tabular-nums;
+}
+
+.extend-timeline-tick-mark {
+  width: 1px;
+  height: 5px;
+  background: #ccc;
+}
+
+.extend-timeline-strip {
+  display: flex;
+  align-items: stretch;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.extend-timeline-strip.reversed {
+  flex-direction: row-reverse;
+}
+
+.extend-timeline-source {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+}
+
+.extend-timeline-source-frame {
+  flex: 1 1 auto;
+  height: 64px;
+  background-color: #1a1a1a;
+  background-size: cover;
+  background-position: center;
+}
+
+.extend-timeline-source-label {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  padding: 2px 6px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 0.66em;
+  letter-spacing: 0.04em;
+}
+
+.extend-timeline-context {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  box-sizing: border-box;
+  border: 2px solid #6c5ce7;
+  background: rgba(108, 92, 231, 0.16);
+  pointer-events: none;
+}
+
+.extend-timeline-context.at-right {
+  right: 0;
+}
+
+.extend-timeline-context.at-left {
+  left: 0;
+}
+
+.extend-timeline-context-label {
+  position: absolute;
+  top: 2px;
+  left: 4px;
+  right: 4px;
+  font-size: 0.62em;
+  color: #fff;
+  background: #6c5ce7;
+  padding: 1px 4px;
+  border-radius: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.extend-timeline-extension {
+  position: relative;
+  background: repeating-linear-gradient(45deg, #f5f5f5 0 6px, #f9f9f9 6px 12px);
+  border-left: 1px dashed #007bff;
+  border-right: 1px dashed #007bff;
+  box-sizing: border-box;
+}
+
+.extend-timeline-fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: #e3f0ff;
+  box-sizing: border-box;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 4px;
+}
+
+.extend-timeline-fill.from-left {
+  left: 0;
+  border-right: 2px solid #007bff;
+}
+
+.extend-timeline-fill.from-right {
+  right: 0;
+  border-left: 2px solid #007bff;
+}
+
+.extend-timeline-fill-pill {
+  font-size: 0.72em;
+  font-weight: 700;
+  color: #007bff;
+  background: #fff;
+  padding: 1px 6px;
+  border-radius: 10px;
+  white-space: nowrap;
+}
+
+.extend-timeline-headroom {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.extend-timeline-headroom span {
+  font-size: 0.7em;
+  color: #666;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  padding: 0 4px;
+}
+
+.extend-timeline-auto {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  pointer-events: none;
+  padding: 0 6px;
+  text-align: center;
+}
+
+.extend-timeline-auto-hint {
+  font-size: 0.66em;
+  color: #666;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.extend-timeline-range {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0.001;
+  cursor: ew-resize;
+}
+
+.extend-timeline-range:disabled {
+  cursor: default;
+}

--- a/src/components/ExtendTimeline.tsx
+++ b/src/components/ExtendTimeline.tsx
@@ -1,0 +1,132 @@
+/**
+ * Visual timeline for extend-video: the source clip strip plus a hatched
+ * band showing how far the selected model can extend it. The band doubles
+ * as a slider (an invisible range input) for setting the extension length.
+ * Purely presentational — all state lives in ExtendVideoOptions.
+ */
+
+import type React from 'react';
+import './ExtendTimeline.css';
+
+export interface ExtendTimelineProps {
+    /** Source clip duration in seconds. */
+    srcDuration: number;
+    /** Poster frame data URL, or null when capture failed. */
+    posterUrl: string | null;
+    /** Extension bounds/step from the capability profile. */
+    minSec: number;
+    maxSec: number;
+    stepSec: number;
+    /** Current extension length in seconds (ignored while durationAuto). */
+    extSec: number;
+    /** FLUX auto mode: the model picks the length; the band is inert. */
+    durationAuto: boolean;
+    /** Where the extension attaches. */
+    mode: 'end' | 'start';
+    /** Context seconds to highlight on the source strip, or null when auto/unsupported. */
+    contextSec: number | null;
+    onExtChange: (seconds: number) => void;
+}
+
+const fmt = (n: number): string => `${(Math.round(n * 10) / 10).toFixed(1)}s`;
+
+export const ExtendTimeline: React.FC<ExtendTimelineProps> = ({
+    srcDuration,
+    posterUrl,
+    minSec,
+    maxSec,
+    stepSec,
+    extSec,
+    durationAuto,
+    mode,
+    contextSec,
+    onExtChange,
+}) => {
+    const atEnd = mode === 'end';
+    const span = srcDuration + maxSec;
+    const srcPct = `${((srcDuration / span) * 100).toFixed(2)}%`;
+    const extPct = `${((maxSec / span) * 100).toFixed(2)}%`;
+    const fillPct = maxSec > 0 ? `${((extSec / maxSec) * 100).toFixed(2)}%` : '0%';
+    const ctxPct =
+        contextSec !== null ? `${((Math.min(contextSec, srcDuration) / srcDuration) * 100).toFixed(2)}%` : '0%';
+
+    // Tick labels every 5s across the whole span; negative side when extending
+    // at the start. Guarded against non-finite spans so a corrupt duration can
+    // never loop unbounded.
+    const ticks: { label: string; left: string }[] = [];
+    if (Number.isFinite(span) && span > 0) {
+        const t0 = atEnd ? 0 : -maxSec;
+        for (let s = Math.ceil(t0 / 5) * 5; s <= t0 + span; s += 5) {
+            ticks.push({
+                label: `${s < 0 ? '−' : ''}${Math.abs(Math.round(s))}s`,
+                left: `${(((s - t0) / span) * 100).toFixed(2)}%`,
+            });
+        }
+    }
+
+    return (
+        <div className="extend-timeline">
+            <div className="extend-timeline-ticks">
+                {ticks.map((t) => (
+                    <div key={t.label} className="extend-timeline-tick" style={{ left: t.left }}>
+                        <span className="extend-timeline-tick-label">{t.label}</span>
+                        <span className="extend-timeline-tick-mark" />
+                    </div>
+                ))}
+            </div>
+
+            <div className={`extend-timeline-strip ${atEnd ? '' : 'reversed'}`}>
+                <div className="extend-timeline-source" style={{ width: srcPct }}>
+                    <div
+                        className="extend-timeline-source-frame"
+                        style={posterUrl ? { backgroundImage: `url(${posterUrl})` } : undefined}
+                    />
+                    <span className="extend-timeline-source-label">SOURCE CLIP</span>
+                    {contextSec !== null && (
+                        <div
+                            className={`extend-timeline-context ${atEnd ? 'at-right' : 'at-left'}`}
+                            style={{ width: ctxPct }}
+                        >
+                            <span className="extend-timeline-context-label">CONTEXT {Math.round(contextSec)}s</span>
+                        </div>
+                    )}
+                </div>
+
+                <div className="extend-timeline-extension" style={{ width: extPct }}>
+                    {durationAuto ? (
+                        <div className="extend-timeline-auto">
+                            <span className="extend-timeline-fill-pill">auto</span>
+                            <span className="extend-timeline-auto-hint">model decides, up to {maxSec}s</span>
+                        </div>
+                    ) : (
+                        <>
+                            <div
+                                className={`extend-timeline-fill ${atEnd ? 'from-left' : 'from-right'}`}
+                                style={{ width: fillPct }}
+                            >
+                                <span className="extend-timeline-fill-pill">+{fmt(extSec)}</span>
+                            </div>
+                            <div
+                                className="extend-timeline-headroom"
+                                style={atEnd ? { left: fillPct, right: 0 } : { right: fillPct, left: 0 }}
+                            >
+                                <span>{fmt(maxSec - extSec)} left</span>
+                            </div>
+                        </>
+                    )}
+                    <input
+                        type="range"
+                        className="extend-timeline-range"
+                        min={minSec}
+                        max={maxSec}
+                        step={stepSec}
+                        value={extSec}
+                        disabled={durationAuto}
+                        onChange={(e) => onExtChange(parseFloat(e.target.value))}
+                        aria-label="Extension length in seconds"
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/components/ExtendVideoOptions.css
+++ b/src/components/ExtendVideoOptions.css
@@ -1,0 +1,222 @@
+/* Extend-video panel: chips, timeline wrapper, and per-model controls */
+
+.extend-panel {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #f9f9f9;
+  overflow: hidden;
+  margin-bottom: 15px;
+}
+
+.extend-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 15px;
+  background: #f0f0f0;
+  flex-wrap: wrap;
+}
+
+.extend-panel-header h4 {
+  margin: 0;
+  font-size: 1em;
+}
+
+.extend-mode-toggle-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.extend-mode-toggle-label {
+  font-size: 0.82em;
+  color: #666;
+}
+
+.extend-end-only-note {
+  font-size: 0.78em;
+  color: #999;
+  letter-spacing: 0.02em;
+}
+
+.extend-toggle {
+  display: flex;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.extend-toggle button {
+  padding: 5px 12px;
+  font-size: 0.82em;
+  border: none;
+  cursor: pointer;
+  background: #fff;
+  color: #555;
+}
+
+.extend-toggle button + button {
+  border-left: 1px solid #ccc;
+}
+
+.extend-toggle button.active {
+  background: #007bff;
+  color: #fff;
+}
+
+.extend-panel-body {
+  padding: 15px;
+}
+
+.extend-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 14px;
+  align-items: center;
+}
+
+.extend-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 12px;
+  background: #f5f5f5;
+  border: 1px solid #e0e0e0;
+  font-size: 0.78em;
+  color: #555;
+}
+
+.extend-chip strong {
+  color: #111;
+}
+
+.extend-chip.accent {
+  background: #e3f0ff;
+  border-color: #007bff;
+  color: #007bff;
+}
+
+.extend-chip.accent strong {
+  color: #007bff;
+}
+
+.extend-chip.success {
+  background: #d4edda;
+  border-color: #c3e6cb;
+  color: #155724;
+}
+
+.extend-chip.warning {
+  background: #fff3cd;
+  border-color: #ffeeba;
+  color: #856404;
+}
+
+.extend-chip.draft {
+  background: #e3f0ff;
+  border: 1px dashed #007bff;
+  color: #007bff;
+}
+
+.extend-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-top: 10px;
+  flex-wrap: wrap;
+}
+
+.extend-summary-math {
+  font-size: 0.9em;
+  color: #555;
+  font-variant-numeric: tabular-nums;
+}
+
+.extend-summary-math .accent {
+  color: #007bff;
+}
+
+.extend-summary-hint {
+  font-size: 0.8em;
+  color: #999;
+}
+
+.extend-warning-note {
+  margin: 10px 0 0;
+  padding: 8px 12px;
+  background: #fff3cd;
+  border: 1px solid #ffeeba;
+  border-radius: 4px;
+  font-size: 0.85em;
+  color: #856404;
+}
+
+.extend-draft-note {
+  margin: 10px 0 0;
+  padding: 8px 12px;
+  background: #e3f0ff;
+  border: 1px solid #007bff;
+  border-radius: 4px;
+  font-size: 0.85em;
+  color: #555;
+}
+
+.extend-unprofiled-note {
+  margin: 0;
+  padding: 12px 15px;
+  font-size: 0.9em;
+  color: #666;
+  font-style: italic;
+}
+
+.extend-divider {
+  height: 1px;
+  background: #e0e0e0;
+  margin: 16px 0;
+}
+
+.extend-control-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 5px;
+}
+
+.extend-control-row label {
+  font-weight: bold;
+}
+
+.extend-value {
+  display: inline-block;
+  min-width: 40px;
+  text-align: center;
+  font-weight: 500;
+  color: #111;
+}
+
+.extend-range {
+  width: 100%;
+  margin: 8px 0;
+  cursor: pointer;
+}
+
+.extend-range:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.extend-link-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #007bff;
+  cursor: pointer;
+  font-size: 0.82em;
+  text-decoration: underline;
+}

--- a/src/components/ExtendVideoOptions.tsx
+++ b/src/components/ExtendVideoOptions.tsx
@@ -1,0 +1,344 @@
+/**
+ * Extend-video panel: source-clip chips, the extend timeline, and the
+ * model-specific controls (duration, mode, context, resolution, audio,
+ * aspect ratio, safety tolerance), all driven by the endpoint's
+ * ExtendCapabilityProfile. Unprofiled endpoints get a minimal notice —
+ * the hook sends only prompt + video_url for them.
+ */
+
+import type React from 'react';
+import { useEffect, useState } from 'react';
+import { useConfig } from '../config';
+import { getExtendCapabilityProfile } from '../services/extendVideoCapabilities';
+import { probeVideoFile, type VideoFileMetadata } from '../utils/videoMetadata';
+import type { ModelConfig } from '../types/models';
+import { ExtendTimeline } from './ExtendTimeline';
+import './ExtendVideoOptions.css';
+
+interface ExtendVideoOptionsProps {
+    selectedModel: ModelConfig;
+    videoFile: File;
+}
+
+const fmt = (n: number): string => `${(Math.round(n * 10) / 10).toFixed(1)}s`;
+
+export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selectedModel, videoFile }) => {
+    const config = useConfig();
+    const profile = getExtendCapabilityProfile(selectedModel.endpointId);
+    const [meta, setMeta] = useState<VideoFileMetadata | null>(null);
+
+    // Probe the uploaded file for duration/dimensions/poster.
+    useEffect(() => {
+        let stale = false;
+        setMeta(null);
+        probeVideoFile(videoFile)
+            .then((m) => {
+                if (!stale) setMeta(m);
+            })
+            .catch(() => {
+                if (!stale) setMeta(null);
+            });
+        return () => {
+            stale = true;
+        };
+    }, [videoFile]);
+
+    // Clamp the stored extension length into the selected model's bounds.
+    useEffect(() => {
+        if (!profile) return;
+        const clamped = Math.min(Math.max(config.extendDuration, profile.durationMin), profile.durationMax);
+        if (clamped !== config.extendDuration) {
+            config.setExtendDuration(clamped);
+        }
+        // Reset resolution/aspect to the profile default when the stored value is invalid.
+        if (profile.resolutions.length > 0 && !profile.resolutions.includes(config.videoResolution)) {
+            config.setVideoResolution(profile.resolutions[0]);
+        }
+        if (profile.aspectRatios.length > 0 && !profile.aspectRatios.includes(config.extendAspectRatio)) {
+            config.setExtendAspectRatio(profile.aspectRatios[0]);
+        }
+    }, [profile, config]);
+
+    if (!profile) {
+        return (
+            <div className="extend-panel">
+                <p className="extend-unprofiled-note">
+                    This endpoint has no capability profile yet — only the prompt and video are sent, and the
+                    model&#39;s own defaults apply.
+                </p>
+            </div>
+        );
+    }
+
+    const durationAuto = profile.supportsAutoDuration && config.extendDurationAuto;
+    const contextAuto = !profile.supportsContext || config.extendContextAuto;
+    const mode = profile.supportsMode && config.extendMode === 'start' ? 'start' : 'end';
+    const extSec = Math.min(Math.max(config.extendDuration, profile.durationMin), profile.durationMax);
+    const effectiveExt = durationAuto ? profile.durationMax : extSec;
+
+    // Guard against degenerate metadata (e.g. streams with unknown duration).
+    const srcDuration = meta && Number.isFinite(meta.duration) && meta.duration > 0 ? meta.duration : null;
+    const srcTooLong =
+        profile.sourceMaxSeconds !== null && srcDuration !== null && srcDuration > profile.sourceMaxSeconds;
+    const totalSec = srcDuration !== null ? srcDuration + effectiveExt : null;
+    const resultOverCeiling =
+        profile.sourceMaxSeconds !== null && totalSec !== null && totalSec > profile.sourceMaxSeconds;
+
+    return (
+        <div className="extend-panel">
+            <div className="extend-panel-header">
+                <h4>Extend Timeline</h4>
+                {profile.supportsMode ? (
+                    <div className="extend-mode-toggle-group">
+                        <span className="extend-mode-toggle-label">Extend at</span>
+                        <div className="extend-toggle">
+                            <button
+                                type="button"
+                                className={mode === 'end' ? 'active' : ''}
+                                onClick={() => config.setExtendMode('end')}
+                            >
+                                End
+                            </button>
+                            <button
+                                type="button"
+                                className={mode === 'start' ? 'active' : ''}
+                                onClick={() => config.setExtendMode('start')}
+                            >
+                                Start
+                            </button>
+                        </div>
+                    </div>
+                ) : (
+                    <span className="extend-end-only-note">
+                        End-only &middot; this model appends after the final frame
+                    </span>
+                )}
+            </div>
+
+            <div className="extend-panel-body">
+                <div className="extend-chips">
+                    <span className="extend-chip">
+                        Source&nbsp;
+                        <strong>{srcDuration !== null ? fmt(srcDuration) : '…'}</strong>
+                        {meta && (
+                            <>
+                                &nbsp;&middot; {meta.width}&times;{meta.height} &middot;{' '}
+                                {(videoFile.size / (1024 * 1024)).toFixed(1)} MB
+                            </>
+                        )}
+                    </span>
+                    <span className="extend-chip accent">
+                        Extendable up to&nbsp;<strong>{profile.durationMax}s</strong>&nbsp;per pass
+                    </span>
+                    {srcDuration !== null && !srcTooLong && (
+                        <span className="extend-chip success">
+                            &#10003; Source accepted by {selectedModel.displayName}
+                        </span>
+                    )}
+                    {srcTooLong && (
+                        <span className="extend-chip warning">
+                            &#9888; Source over the {profile.sourceMaxSeconds}s limit for this model
+                        </span>
+                    )}
+                    {profile.isDraft && <span className="extend-chip draft">Draft preview &middot; 720p only</span>}
+                </div>
+
+                {srcDuration !== null && (
+                    <ExtendTimeline
+                        srcDuration={srcDuration}
+                        posterUrl={meta?.posterUrl ?? null}
+                        minSec={profile.durationMin}
+                        maxSec={profile.durationMax}
+                        stepSec={profile.durationStep}
+                        extSec={extSec}
+                        durationAuto={durationAuto}
+                        mode={mode}
+                        contextSec={profile.supportsContext && !contextAuto ? config.extendContext : null}
+                        onExtChange={config.setExtendDuration}
+                    />
+                )}
+
+                {srcDuration !== null && totalSec !== null && (
+                    <div className="extend-summary">
+                        <span className="extend-summary-math">
+                            {fmt(srcDuration)} source{' '}
+                            <strong className="accent">+ {durationAuto ? 'auto' : fmt(extSec)}</strong> ={' '}
+                            <strong>{durationAuto ? `up to ${fmt(totalSec)}` : fmt(totalSec)} total</strong>
+                        </span>
+                        <span className="extend-summary-hint">
+                            {durationAuto
+                                ? 'Switch to Manual to set the length yourself'
+                                : 'Drag the highlighted band to set the extension'}
+                        </span>
+                    </div>
+                )}
+
+                {resultOverCeiling && (
+                    <p className="extend-warning-note">
+                        Result is {totalSec !== null ? fmt(totalSec) : ''} &mdash; past the {profile.sourceMaxSeconds}s
+                        source ceiling, so it cannot be fed back in for another extension pass.
+                    </p>
+                )}
+
+                {profile.isDraft && (
+                    <p className="extend-draft-note">
+                        Returns a reusable draft cache alongside the video &mdash; the result can be re-rendered at full
+                        quality without paying for another draft pass.
+                    </p>
+                )}
+
+                <div className="extend-divider" />
+
+                <div className="form-group">
+                    <div className="extend-control-row">
+                        <label htmlFor="extend-duration">
+                            Extension Duration:{' '}
+                            <span className="extend-value">{durationAuto ? 'auto' : fmt(extSec)}</span>
+                        </label>
+                        {profile.supportsAutoDuration && (
+                            <div className="extend-toggle">
+                                <button
+                                    type="button"
+                                    className={durationAuto ? 'active' : ''}
+                                    onClick={() => config.setExtendDurationAuto(true)}
+                                >
+                                    Auto
+                                </button>
+                                <button
+                                    type="button"
+                                    className={durationAuto ? '' : 'active'}
+                                    onClick={() => config.setExtendDurationAuto(false)}
+                                >
+                                    Manual
+                                </button>
+                            </div>
+                        )}
+                    </div>
+                    <input
+                        id="extend-duration"
+                        type="range"
+                        min={profile.durationMin}
+                        max={profile.durationMax}
+                        step={profile.durationStep}
+                        value={extSec}
+                        disabled={durationAuto}
+                        onChange={(e) => config.setExtendDuration(parseFloat(e.target.value))}
+                        className="extend-range"
+                    />
+                    <span className="hint">
+                        {durationAuto
+                            ? `(auto — the model picks the length, ${profile.durationMin}–${profile.durationMax}s)`
+                            : `(${profile.durationMin}–${profile.durationMax}s per pass, ${
+                                  profile.durationStep === 1 ? 'whole seconds' : `${profile.durationStep}s steps`
+                              })`}
+                    </span>
+                </div>
+
+                {profile.supportsContext && (
+                    <div className="form-group">
+                        <div className="extend-control-row">
+                            <label htmlFor="extend-context">
+                                Context Window:{' '}
+                                <span className="extend-value">
+                                    {contextAuto ? 'auto' : `${config.extendContext}s`}
+                                </span>
+                            </label>
+                            <button
+                                type="button"
+                                className="extend-link-btn"
+                                onClick={() => config.setExtendContextAuto(!config.extendContextAuto)}
+                            >
+                                {contextAuto ? 'Set manually' : 'Use auto'}
+                            </button>
+                        </div>
+                        {contextAuto ? (
+                            <span className="hint">
+                                Field omitted &mdash; the model maximizes context within its 505-frame limit.
+                            </span>
+                        ) : (
+                            <>
+                                <input
+                                    id="extend-context"
+                                    type="range"
+                                    min={1}
+                                    max={20}
+                                    step={1}
+                                    value={config.extendContext}
+                                    onChange={(e) => config.setExtendContext(parseInt(e.target.value, 10))}
+                                    className="extend-range"
+                                />
+                                <span className="hint">(1&ndash;20s of the source the model conditions on)</span>
+                            </>
+                        )}
+                    </div>
+                )}
+
+                {profile.resolutions.length > 0 && (
+                    <div className="form-group">
+                        <label htmlFor="extend-resolution">Resolution:</label>
+                        <select
+                            id="extend-resolution"
+                            value={config.videoResolution}
+                            onChange={(e) => config.setVideoResolution(e.target.value)}
+                        >
+                            {profile.resolutions.map((res) => (
+                                <option key={res} value={res}>
+                                    {res}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                )}
+
+                {profile.supportsGenerateAudio && (
+                    <div className="form-group">
+                        <label htmlFor="extend-generate-audio">Generate Audio:</label>
+                        <input
+                            id="extend-generate-audio"
+                            type="checkbox"
+                            checked={config.generateAudio}
+                            onChange={(e) => config.setGenerateAudio(e.target.checked)}
+                        />
+                        <span className="hint"> (continues the source clip&#39;s audio)</span>
+                    </div>
+                )}
+
+                {profile.aspectRatios.length > 0 && (
+                    <div className="form-group">
+                        <label htmlFor="extend-aspect-ratio">Aspect Ratio:</label>
+                        <select
+                            id="extend-aspect-ratio"
+                            value={config.extendAspectRatio}
+                            onChange={(e) => config.setExtendAspectRatio(e.target.value)}
+                        >
+                            {profile.aspectRatios.map((ratio) => (
+                                <option key={ratio} value={ratio}>
+                                    {ratio}
+                                </option>
+                            ))}
+                        </select>
+                        <span className="hint"> (auto keeps the source clip&#39;s ratio)</span>
+                    </div>
+                )}
+
+                {profile.supportsSafetyTolerance && (
+                    <div className="form-group">
+                        <label htmlFor="extend-safety-tolerance">Safety Tolerance:</label>
+                        <select
+                            id="extend-safety-tolerance"
+                            value={config.extendSafetyTolerance}
+                            onChange={(e) => config.setExtendSafetyTolerance(parseInt(e.target.value, 10))}
+                        >
+                            {[0, 1, 2, 3, 4].map((level) => (
+                                <option key={level} value={level}>
+                                    {level}
+                                </option>
+                            ))}
+                        </select>
+                        <span className="hint"> (0 = strictest, 4 = most permissive)</span>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/src/components/ExtendVideoOptions.tsx
+++ b/src/components/ExtendVideoOptions.tsx
@@ -7,10 +7,10 @@
  */
 
 import type React from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useConfig } from '../config';
 import { getExtendCapabilityProfile } from '../services/extendVideoCapabilities';
-import { probeVideoFile, type VideoFileMetadata } from '../utils/videoMetadata';
+import type { VideoFileMetadata } from '../utils/videoMetadata';
 import type { ModelConfig } from '../types/models';
 import { ExtendTimeline } from './ExtendTimeline';
 import './ExtendVideoOptions.css';
@@ -18,30 +18,15 @@ import './ExtendVideoOptions.css';
 interface ExtendVideoOptionsProps {
     selectedModel: ModelConfig;
     videoFile: File;
+    /** Probed source metadata, owned by InputSection (which also gates Generate on it). */
+    meta: VideoFileMetadata | null;
 }
 
 const fmt = (n: number): string => `${(Math.round(n * 10) / 10).toFixed(1)}s`;
 
-export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selectedModel, videoFile }) => {
+export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selectedModel, videoFile, meta }) => {
     const config = useConfig();
     const profile = getExtendCapabilityProfile(selectedModel.endpointId);
-    const [meta, setMeta] = useState<VideoFileMetadata | null>(null);
-
-    // Probe the uploaded file for duration/dimensions/poster.
-    useEffect(() => {
-        let stale = false;
-        setMeta(null);
-        probeVideoFile(videoFile)
-            .then((m) => {
-                if (!stale) setMeta(m);
-            })
-            .catch(() => {
-                if (!stale) setMeta(null);
-            });
-        return () => {
-            stale = true;
-        };
-    }, [videoFile]);
 
     // Clamp the stored extension length into the selected model's bounds.
     useEffect(() => {
@@ -137,7 +122,8 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
                     )}
                     {srcTooLong && (
                         <span className="extend-chip warning">
-                            &#9888; Source over the {profile.sourceMaxSeconds}s limit for this model
+                            &#9888; Source over the {profile.sourceMaxSeconds}s limit for this model &mdash; trim the
+                            clip to extend it
                         </span>
                     )}
                     {profile.isDraft && <span className="extend-chip draft">Draft preview &middot; 720p only</span>}
@@ -182,8 +168,8 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
 
                 {profile.isDraft && (
                     <p className="extend-draft-note">
-                        Returns a reusable draft cache alongside the video &mdash; the result can be re-rendered at full
-                        quality without paying for another draft pass.
+                        The API also returns a draft cache for discounted full-quality re-rendering &mdash; this app
+                        doesn&#39;t support the enhance step yet.
                     </p>
                 )}
 

--- a/src/components/ExtendVideoOptions.tsx
+++ b/src/components/ExtendVideoOptions.tsx
@@ -9,7 +9,11 @@
 import type React from 'react';
 import { useEffect } from 'react';
 import { useConfig } from '../config';
-import { getExtendCapabilityProfile } from '../services/extendVideoCapabilities';
+import {
+    checkExtendSource,
+    formatSourceMaxBytes,
+    getExtendCapabilityProfile,
+} from '../services/extendVideoCapabilities';
 import type { VideoFileMetadata } from '../utils/videoMetadata';
 import type { ModelConfig } from '../types/models';
 import { ExtendTimeline } from './ExtendTimeline';
@@ -63,8 +67,9 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
 
     // Guard against degenerate metadata (e.g. streams with unknown duration).
     const srcDuration = meta && Number.isFinite(meta.duration) && meta.duration > 0 ? meta.duration : null;
-    const srcTooLong =
-        profile.sourceMaxSeconds !== null && srcDuration !== null && srcDuration > profile.sourceMaxSeconds;
+    // One predicate for duration, size, and container — the same check gates
+    // Generate in InputSection, so chips and button state always agree.
+    const srcCheck = checkExtendSource(profile, videoFile, srcDuration);
     const totalSec = srcDuration !== null ? srcDuration + effectiveExt : null;
     const resultOverCeiling =
         profile.sourceMaxSeconds !== null && totalSec !== null && totalSec > profile.sourceMaxSeconds;
@@ -115,16 +120,25 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
                     <span className="extend-chip accent">
                         Extendable up to&nbsp;<strong>{profile.durationMax}s</strong>&nbsp;per pass
                     </span>
-                    {srcDuration !== null && !srcTooLong && (
+                    {srcCheck.accepted && (
                         <span className="extend-chip success">
                             &#10003; Source accepted by {selectedModel.displayName}
                         </span>
                     )}
-                    {srcTooLong && (
+                    {srcCheck.tooLong && (
                         <span className="extend-chip warning">
                             &#9888; Source over the {profile.sourceMaxSeconds}s limit for this model &mdash; trim the
                             clip to extend it
                         </span>
+                    )}
+                    {srcCheck.tooLarge && profile.sourceMaxBytes !== null && (
+                        <span className="extend-chip warning">
+                            &#9888; Source is {(videoFile.size / 1_000_000).toFixed(1)} MB &mdash; over the{' '}
+                            {formatSourceMaxBytes(profile.sourceMaxBytes)} limit for this model
+                        </span>
+                    )}
+                    {srcCheck.wrongContainer && (
+                        <span className="extend-chip warning">&#9888; Source must be an MP4 file for this model</span>
                     )}
                     {profile.isDraft && <span className="extend-chip draft">Draft preview &middot; 720p only</span>}
                 </div>

--- a/src/components/GenerationTabs.tsx
+++ b/src/components/GenerationTabs.tsx
@@ -14,6 +14,7 @@ export type GenerationMode =
     | 'image-to-video'
     | 'video-to-video'
     | 'reference-to-video'
+    | 'extend-video'
     | 'text-to-speech'
     | 'text-to-audio'
     | 'audio-to-audio'
@@ -39,7 +40,8 @@ export function isVideoMode(mode: GenerationMode): boolean {
         mode === 'text-to-video' ||
         mode === 'image-to-video' ||
         mode === 'video-to-video' ||
-        mode === 'reference-to-video'
+        mode === 'reference-to-video' ||
+        mode === 'extend-video'
     );
 }
 
@@ -61,7 +63,7 @@ export function requiresImageInput(mode: GenerationMode): boolean {
 
 /** Helper to check if a mode requires video input */
 export function requiresVideoInput(mode: GenerationMode): boolean {
-    return mode === 'video-to-video' || mode === 'video-to-audio';
+    return mode === 'video-to-video' || mode === 'video-to-audio' || mode === 'extend-video';
 }
 
 /** Helper to check if a mode requires audio input */
@@ -78,6 +80,7 @@ export function isValidGenerationMode(value: string): value is GenerationMode {
         value === 'image-to-video' ||
         value === 'video-to-video' ||
         value === 'reference-to-video' ||
+        value === 'extend-video' ||
         value === 'text-to-speech' ||
         value === 'text-to-audio' ||
         value === 'audio-to-audio' ||

--- a/src/components/InputSection.tsx
+++ b/src/components/InputSection.tsx
@@ -11,7 +11,7 @@ import { VideoUploadZone } from './VideoUploadZone';
 import { AudioUploadZone } from './AudioUploadZone';
 import { ExtendVideoOptions } from './ExtendVideoOptions';
 import { getImageInputConfig } from '../services/modelParams';
-import { getExtendCapabilityProfile } from '../services/extendVideoCapabilities';
+import { checkExtendSource, getExtendCapabilityProfile } from '../services/extendVideoCapabilities';
 import { useVideoFileMetadata } from '../hooks/useVideoFileMetadata';
 
 export interface InputSectionProps {
@@ -107,15 +107,15 @@ export const InputSection: React.FC<InputSectionProps> = ({
     const extendPromptMissing = isExtendVideo && !extendPromptOptional && !promptText.trim();
 
     // Probe the source clip once here (shared with ExtendVideoOptions below)
-    // so a clip over the model's ceiling disables Generate instead of only
-    // warning. Unknown metadata (null) doesn't block — the hook revalidates.
+    // so a clip violating the model's source constraints (duration ceiling,
+    // file size, container) disables Generate instead of only warning.
+    // Unknown metadata doesn't block — the hook revalidates before upload.
     const extendVideoMeta = useVideoFileMetadata(isExtendVideo ? uploadedVideoFile : null);
-    const extendSourceTooLong =
+    const extendSourceBlocked =
         isExtendVideo &&
         extendProfile !== undefined &&
-        extendProfile.sourceMaxSeconds !== null &&
-        extendVideoMeta !== null &&
-        extendVideoMeta.duration > extendProfile.sourceMaxSeconds;
+        uploadedVideoFile !== null &&
+        checkExtendSource(extendProfile, uploadedVideoFile, extendVideoMeta?.duration ?? null).blocked;
 
     return (
         <div className="input-section">
@@ -205,7 +205,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
                 className="generate-btn"
                 onClick={handleGenerate}
                 disabled={
-                    !currentSelectedModel || modelsLoading || isGenerating || extendPromptMissing || extendSourceTooLong
+                    !currentSelectedModel || modelsLoading || isGenerating || extendPromptMissing || extendSourceBlocked
                 }
             >
                 {getGenerateButtonText()}

--- a/src/components/InputSection.tsx
+++ b/src/components/InputSection.tsx
@@ -9,7 +9,9 @@ import { PromptOptimizer } from './PromptOptimizer';
 import { ImageUploadZone } from './ImageUploadZone';
 import { VideoUploadZone } from './VideoUploadZone';
 import { AudioUploadZone } from './AudioUploadZone';
+import { ExtendVideoOptions } from './ExtendVideoOptions';
 import { getImageInputConfig } from '../services/modelParams';
+import { getExtendCapabilityProfile } from '../services/extendVideoCapabilities';
 
 export interface InputSectionProps {
     activeTab: GenerationMode;
@@ -58,6 +60,8 @@ export const InputSection: React.FC<InputSectionProps> = ({
                 return 'Transform this video into...';
             case 'reference-to-video':
                 return 'Use @Image1, @Image2... in your prompt to reference uploaded images';
+            case 'extend-video':
+                return 'The camera keeps drifting right as the ripples settle and dusk falls...';
             case 'text-to-speech':
                 return 'Hello, welcome to the presentation...';
             case 'text-to-audio':
@@ -77,6 +81,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
         if (isGenerating) return 'Generating...';
         if (modelsLoading) return 'Loading models...';
         if (activeTab === 'audio-understanding') return 'Analyze Audio';
+        if (activeTab === 'extend-video') return 'Extend Video';
         if (isAudioMode(activeTab)) return 'Generate Audio';
         if (isVideoMode(activeTab)) return 'Generate Video';
         return 'Generate Image';
@@ -91,6 +96,14 @@ export const InputSection: React.FC<InputSectionProps> = ({
         }
         return 'Enter your prompt:';
     };
+
+    // Extend mode: prompt requirement varies per endpoint (required for FLUX,
+    // optional for LTX 2.3 Pro). Unprofiled endpoints default to required.
+    const isExtendVideo = activeTab === 'extend-video';
+    const extendProfile =
+        isExtendVideo && currentSelectedModel ? getExtendCapabilityProfile(currentSelectedModel.endpointId) : undefined;
+    const extendPromptOptional = isExtendVideo && extendProfile !== undefined && !extendProfile.promptRequired;
+    const extendPromptMissing = isExtendVideo && !extendPromptOptional && !promptText.trim();
 
     return (
         <div className="input-section">
@@ -142,11 +155,24 @@ export const InputSection: React.FC<InputSectionProps> = ({
                 />
             )}
 
-            <ModelConfigPanel selectedModel={currentSelectedModel} activeTab={activeTab} />
+            {/* Extend mode owns all model settings in its own panel; the generic
+                config panel would render inapplicable video options for it. */}
+            {isExtendVideo && currentSelectedModel && uploadedVideoFile && (
+                <ExtendVideoOptions selectedModel={currentSelectedModel} videoFile={uploadedVideoFile} />
+            )}
+            {!isExtendVideo && <ModelConfigPanel selectedModel={currentSelectedModel} activeTab={activeTab} />}
 
             <PromptOptimizer originalPrompt={promptText} onPromptOptimized={(optimized) => setPromptText(optimized)} />
 
-            <label htmlFor="prompt-input">{getInputLabel()}</label>
+            <label htmlFor="prompt-input">
+                {getInputLabel()}
+                {isExtendVideo && !extendPromptOptional && <span className="prompt-required-mark"> *</span>}
+            </label>
+            {extendPromptOptional && (
+                <span className="prompt-optional-hint">
+                    Optional &mdash; describe what should happen in the extension.
+                </span>
+            )}
             <TextareaAutosize
                 id="prompt-input"
                 value={promptText}
@@ -162,7 +188,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
                 type="button"
                 className="generate-btn"
                 onClick={handleGenerate}
-                disabled={!currentSelectedModel || modelsLoading || isGenerating}
+                disabled={!currentSelectedModel || modelsLoading || isGenerating || extendPromptMissing}
             >
                 {getGenerateButtonText()}
             </button>

--- a/src/components/InputSection.tsx
+++ b/src/components/InputSection.tsx
@@ -12,6 +12,7 @@ import { AudioUploadZone } from './AudioUploadZone';
 import { ExtendVideoOptions } from './ExtendVideoOptions';
 import { getImageInputConfig } from '../services/modelParams';
 import { getExtendCapabilityProfile } from '../services/extendVideoCapabilities';
+import { useVideoFileMetadata } from '../hooks/useVideoFileMetadata';
 
 export interface InputSectionProps {
     activeTab: GenerationMode;
@@ -105,6 +106,17 @@ export const InputSection: React.FC<InputSectionProps> = ({
     const extendPromptOptional = isExtendVideo && extendProfile !== undefined && !extendProfile.promptRequired;
     const extendPromptMissing = isExtendVideo && !extendPromptOptional && !promptText.trim();
 
+    // Probe the source clip once here (shared with ExtendVideoOptions below)
+    // so a clip over the model's ceiling disables Generate instead of only
+    // warning. Unknown metadata (null) doesn't block — the hook revalidates.
+    const extendVideoMeta = useVideoFileMetadata(isExtendVideo ? uploadedVideoFile : null);
+    const extendSourceTooLong =
+        isExtendVideo &&
+        extendProfile !== undefined &&
+        extendProfile.sourceMaxSeconds !== null &&
+        extendVideoMeta !== null &&
+        extendVideoMeta.duration > extendProfile.sourceMaxSeconds;
+
     return (
         <div className="input-section">
             <ModelSelector filterByCategory={activeTab} />
@@ -158,7 +170,11 @@ export const InputSection: React.FC<InputSectionProps> = ({
             {/* Extend mode owns all model settings in its own panel; the generic
                 config panel would render inapplicable video options for it. */}
             {isExtendVideo && currentSelectedModel && uploadedVideoFile && (
-                <ExtendVideoOptions selectedModel={currentSelectedModel} videoFile={uploadedVideoFile} />
+                <ExtendVideoOptions
+                    selectedModel={currentSelectedModel}
+                    videoFile={uploadedVideoFile}
+                    meta={extendVideoMeta}
+                />
             )}
             {!isExtendVideo && <ModelConfigPanel selectedModel={currentSelectedModel} activeTab={activeTab} />}
 
@@ -188,7 +204,9 @@ export const InputSection: React.FC<InputSectionProps> = ({
                 type="button"
                 className="generate-btn"
                 onClick={handleGenerate}
-                disabled={!currentSelectedModel || modelsLoading || isGenerating || extendPromptMissing}
+                disabled={
+                    !currentSelectedModel || modelsLoading || isGenerating || extendPromptMissing || extendSourceTooLong
+                }
             >
                 {getGenerateButtonText()}
             </button>

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -46,12 +46,12 @@ describe('buildVisibleNodes', () => {
 
     it('includes all children when all sections expanded', () => {
         const nodes = buildVisibleNodes(new Set(['image', 'video', 'audio', 'history']));
-        // 4 sections + 2 image + 4 video + 5 audio + 3 history = 18
-        expect(nodes).toHaveLength(18);
+        // 4 sections + 2 image + 5 video + 5 audio + 3 history = 19
+        expect(nodes).toHaveLength(19);
         expect(nodes[0]).toEqual({ type: 'section', sectionId: 'image' });
         expect(nodes[3]).toEqual({ type: 'section', sectionId: 'video' });
-        expect(nodes[8]).toEqual({ type: 'section', sectionId: 'audio' });
-        expect(nodes[14]).toEqual({ type: 'section', sectionId: 'history' });
+        expect(nodes[9]).toEqual({ type: 'section', sectionId: 'audio' });
+        expect(nodes[15]).toEqual({ type: 'section', sectionId: 'history' });
     });
 });
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -62,6 +62,7 @@ const sections: SectionConfig[] = [
             { id: 'image-to-video', label: 'Image to Video' },
             { id: 'video-to-video', label: 'Video to Video' },
             { id: 'reference-to-video', label: 'Reference to Video' },
+            { id: 'extend-video', label: 'Extend Video' },
         ],
     },
     {

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -48,6 +48,14 @@ export interface ConfigState {
     videoEnablePromptExpansion: boolean; // default false
     // Video-to-video settings
     videoStrength: number; // 0-1, strength for video-to-video transformation
+    // Extend-video settings (per-endpoint capabilities in services/extendVideoCapabilities.ts)
+    extendDuration: number; // Extension length in seconds
+    extendDurationAuto: boolean; // FLUX only: let the model choose (omits `duration`)
+    extendMode: string; // 'end' | 'start' (LTX only)
+    extendContext: number; // LTX only: seconds of source context (1-20)
+    extendContextAuto: boolean; // LTX only: omit `context` to maximize it
+    extendAspectRatio: string; // FLUX only: 'auto', '21:9', '2:1', ...
+    extendSafetyTolerance: number; // FLUX only: 0 (strict) - 4 (permissive)
     // Audio generation settings
     audioOutputFormat: string; // 'mp3' | 'wav' | 'flac' | 'pcm'
     audioSeed: number | null; // Seed for reproducibility
@@ -145,6 +153,14 @@ interface ConfigContextType extends ConfigState {
     setVideoEnablePromptExpansion: (value: boolean) => void;
     // Video-to-video setters
     setVideoStrength: (value: number) => void;
+    // Extend-video setters
+    setExtendDuration: (value: number) => void;
+    setExtendDurationAuto: (value: boolean) => void;
+    setExtendMode: (value: string) => void;
+    setExtendContext: (value: number) => void;
+    setExtendContextAuto: (value: boolean) => void;
+    setExtendAspectRatio: (value: string) => void;
+    setExtendSafetyTolerance: (value: number) => void;
     // Audio generation setters
     setAudioOutputFormat: (value: string) => void;
     setAudioSeed: (value: number | null) => void;
@@ -298,6 +314,26 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
     const [videoStrength, setVideoStrength] = useState<number>(
         parseFloat(localStorage.getItem('VIDEO_STRENGTH') || '0.5'),
     );
+    // Extend-video settings
+    const [extendDuration, setExtendDuration] = useState<number>(
+        parseFloat(localStorage.getItem('EXTEND_DURATION') || '5'),
+    );
+    const [extendDurationAuto, setExtendDurationAuto] = useState<boolean>(
+        localStorage.getItem('EXTEND_DURATION_AUTO') !== 'false', // Default true
+    );
+    const [extendMode, setExtendMode] = useState<string>(localStorage.getItem('EXTEND_MODE') || 'end');
+    const [extendContext, setExtendContext] = useState<number>(
+        parseInt(localStorage.getItem('EXTEND_CONTEXT') || '5', 10),
+    );
+    const [extendContextAuto, setExtendContextAuto] = useState<boolean>(
+        localStorage.getItem('EXTEND_CONTEXT_AUTO') !== 'false', // Default true
+    );
+    const [extendAspectRatio, setExtendAspectRatio] = useState<string>(
+        localStorage.getItem('EXTEND_ASPECT_RATIO') || 'auto',
+    );
+    const [extendSafetyTolerance, setExtendSafetyTolerance] = useState<number>(
+        parseInt(localStorage.getItem('EXTEND_SAFETY_TOLERANCE') || '2', 10),
+    );
     // Audio generation settings
     const [audioOutputFormat, setAudioOutputFormat] = useState<string>(
         localStorage.getItem('AUDIO_OUTPUT_FORMAT') || 'mp3',
@@ -446,6 +482,14 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
         localStorage.setItem('VIDEO_ENABLE_PROMPT_EXPANSION', videoEnablePromptExpansion.toString());
         // Video-to-video persistence
         localStorage.setItem('VIDEO_STRENGTH', videoStrength.toString());
+        // Extend-video persistence
+        localStorage.setItem('EXTEND_DURATION', extendDuration.toString());
+        localStorage.setItem('EXTEND_DURATION_AUTO', extendDurationAuto.toString());
+        localStorage.setItem('EXTEND_MODE', extendMode);
+        localStorage.setItem('EXTEND_CONTEXT', extendContext.toString());
+        localStorage.setItem('EXTEND_CONTEXT_AUTO', extendContextAuto.toString());
+        localStorage.setItem('EXTEND_ASPECT_RATIO', extendAspectRatio);
+        localStorage.setItem('EXTEND_SAFETY_TOLERANCE', extendSafetyTolerance.toString());
         // Audio generation persistence
         localStorage.setItem('AUDIO_OUTPUT_FORMAT', audioOutputFormat);
         localStorage.setItem('AUDIO_SEED', audioSeed !== null ? audioSeed.toString() : 'null');
@@ -534,6 +578,13 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
         videoCameraLoraScale,
         videoEnablePromptExpansion,
         videoStrength,
+        extendDuration,
+        extendDurationAuto,
+        extendMode,
+        extendContext,
+        extendContextAuto,
+        extendAspectRatio,
+        extendSafetyTolerance,
         audioOutputFormat,
         audioSeed,
         ttsVoiceId,
@@ -654,6 +705,21 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
                 // Video-to-video settings
                 videoStrength,
                 setVideoStrength,
+                // Extend-video settings
+                extendDuration,
+                setExtendDuration,
+                extendDurationAuto,
+                setExtendDurationAuto,
+                extendMode,
+                setExtendMode,
+                extendContext,
+                setExtendContext,
+                extendContextAuto,
+                setExtendContextAuto,
+                extendAspectRatio,
+                setExtendAspectRatio,
+                extendSafetyTolerance,
+                setExtendSafetyTolerance,
                 // Audio generation
                 audioOutputFormat,
                 setAudioOutputFormat,

--- a/src/contexts/ModelsContext.tsx
+++ b/src/contexts/ModelsContext.tsx
@@ -331,13 +331,15 @@ export const ModelsProvider: React.FC<ModelsProviderProps> = ({ children }) => {
 
             let filtered = category ? sourceModels.filter((m) => m.category === category) : sourceModels;
 
-            // fal.ai's catalog categorizes Seedance reference-to-video under `image-to-video`,
-            // so the fetched-all path would otherwise return nothing for our `reference-to-video`
-            // UX category. Always seed it from the curated list so the user sees something.
-            if (category === 'reference-to-video' && showAllVideoModels) {
-                const curatedR2V = curatedVideoModels.filter((m) => m.category === 'reference-to-video');
+            // fal.ai's catalog categorizes Seedance reference-to-video under `image-to-video`
+            // and extend endpoints under `video-to-video`, so the fetched-all path would
+            // otherwise return nothing for these UX categories (normalizeModel recategorizes
+            // by endpoint suffix, but only for endpoints the catalog page returned). Always
+            // seed them from the curated list so the user sees something.
+            if ((category === 'reference-to-video' || category === 'extend-video') && showAllVideoModels) {
+                const curatedForCategory = curatedVideoModels.filter((m) => m.category === category);
                 const fetchedIds = new Set(filtered.map((m) => m.endpointId));
-                filtered = [...filtered, ...curatedR2V.filter((m) => !fetchedIds.has(m.endpointId))];
+                filtered = [...filtered, ...curatedForCategory.filter((m) => !fetchedIds.has(m.endpointId))];
             }
 
             if (showAllVideoModels && videoSearchQuery) {

--- a/src/hooks/useVideoFileMetadata.ts
+++ b/src/hooks/useVideoFileMetadata.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { probeVideoFile, type VideoFileMetadata } from '../utils/videoMetadata';
+
+/**
+ * Probe an uploaded video file for duration/dimensions/poster. Returns null
+ * while probing, when there is no file, or when metadata is unreadable —
+ * callers that gate on limits should treat null as "unknown, let the API
+ * decide" rather than as a failure.
+ */
+export function useVideoFileMetadata(file: File | null): VideoFileMetadata | null {
+    const [meta, setMeta] = useState<VideoFileMetadata | null>(null);
+
+    useEffect(() => {
+        let stale = false;
+        setMeta(null);
+        if (!file) {
+            return;
+        }
+        probeVideoFile(file)
+            .then((m) => {
+                if (!stale) setMeta(m);
+            })
+            .catch(() => {
+                if (!stale) setMeta(null);
+            });
+        return () => {
+            stale = true;
+        };
+    }, [file]);
+
+    return meta;
+}

--- a/src/hooks/useVideoGeneration.ts
+++ b/src/hooks/useVideoGeneration.ts
@@ -6,7 +6,11 @@ import type { ConfigState } from '../config';
 import { parseFalError } from '../services/errors';
 import { getImageInputConfig } from '../services/modelParams';
 import { activeLongDurationConstraint, getVideoCapabilityProfile } from '../services/videoModelCapabilities';
-import { getExtendCapabilityProfile } from '../services/extendVideoCapabilities';
+import {
+    checkExtendSource,
+    formatSourceMaxBytes,
+    getExtendCapabilityProfile,
+} from '../services/extendVideoCapabilities';
 import { isSeedanceModel } from '../services/videoModels';
 import { FalQueueCancelledError, FalQueueTimeoutError, submitAndPollFalQueue } from '../services/falQueue';
 import { probeVideoFile } from '../utils/videoMetadata';
@@ -91,21 +95,37 @@ export function useVideoGeneration({
                 return;
             }
 
-            // Extend mode: reject sources over the model's ceiling before paying
-            // for a storage upload. The UI disables Generate too, but revalidate
+            // Extend mode: reject sources violating the model's constraints
+            // (duration ceiling, file size, container) before paying for a
+            // storage upload. The UI disables Generate too, but revalidate
             // here in case its metadata probe lagged or failed.
-            if (isExtendVideo && extendProfile && extendProfile.sourceMaxSeconds !== null && uploadedVideoFile) {
-                try {
-                    const meta = await probeVideoFile(uploadedVideoFile);
-                    if (meta.duration > extendProfile.sourceMaxSeconds) {
-                        setStatus(
-                            `Source clip is ${meta.duration.toFixed(1)}s — over the ${extendProfile.sourceMaxSeconds}s limit for ${modelName}.`,
-                            'error',
-                        );
-                        return;
+            if (isExtendVideo && extendProfile && uploadedVideoFile) {
+                let sourceDuration: number | null = null;
+                if (extendProfile.sourceMaxSeconds !== null) {
+                    try {
+                        sourceDuration = (await probeVideoFile(uploadedVideoFile)).duration;
+                    } catch {
+                        // Unreadable metadata locally — let the API validate the upload.
                     }
-                } catch {
-                    // Unreadable metadata locally — let the API validate the upload.
+                }
+                const sourceCheck = checkExtendSource(extendProfile, uploadedVideoFile, sourceDuration);
+                if (sourceCheck.tooLong && sourceDuration !== null) {
+                    setStatus(
+                        `Source clip is ${sourceDuration.toFixed(1)}s — over the ${extendProfile.sourceMaxSeconds}s limit for ${modelName}.`,
+                        'error',
+                    );
+                    return;
+                }
+                if (sourceCheck.tooLarge && extendProfile.sourceMaxBytes !== null) {
+                    setStatus(
+                        `Source file is ${(uploadedVideoFile.size / 1_000_000).toFixed(1)} MB — over the ${formatSourceMaxBytes(extendProfile.sourceMaxBytes)} limit for ${modelName}.`,
+                        'error',
+                    );
+                    return;
+                }
+                if (sourceCheck.wrongContainer) {
+                    setStatus(`Source must be an MP4 file for ${modelName}.`, 'error');
+                    return;
                 }
             }
 

--- a/src/hooks/useVideoGeneration.ts
+++ b/src/hooks/useVideoGeneration.ts
@@ -4,12 +4,16 @@ import type { GenerationMode } from '../components/GenerationTabs';
 import type { ModelConfig } from '../types/models';
 import type { ConfigState } from '../config';
 import { parseFalError } from '../services/errors';
-import { sanitizeLogMessage } from '../utils/logSanitizer';
 import { getImageInputConfig } from '../services/modelParams';
 import { activeLongDurationConstraint, getVideoCapabilityProfile } from '../services/videoModelCapabilities';
 import { getExtendCapabilityProfile } from '../services/extendVideoCapabilities';
 import { isSeedanceModel } from '../services/videoModels';
+import { FalQueueCancelledError, FalQueueTimeoutError, submitAndPollFalQueue } from '../services/falQueue';
+import { probeVideoFile } from '../utils/videoMetadata';
 import type { StatusType } from './useStatusMessage';
+
+const POLL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const POLL_INTERVAL_MS = 3000; // longer poll interval for video
 
 export interface UseVideoGenerationParams {
     activeTab: GenerationMode;
@@ -85,6 +89,24 @@ export function useVideoGeneration({
             if (isReferenceToVideo && uploadedImages.length === 0) {
                 setStatus('Please upload at least one reference image for reference-to-video generation.', 'error');
                 return;
+            }
+
+            // Extend mode: reject sources over the model's ceiling before paying
+            // for a storage upload. The UI disables Generate too, but revalidate
+            // here in case its metadata probe lagged or failed.
+            if (isExtendVideo && extendProfile && extendProfile.sourceMaxSeconds !== null && uploadedVideoFile) {
+                try {
+                    const meta = await probeVideoFile(uploadedVideoFile);
+                    if (meta.duration > extendProfile.sourceMaxSeconds) {
+                        setStatus(
+                            `Source clip is ${meta.duration.toFixed(1)}s — over the ${extendProfile.sourceMaxSeconds}s limit for ${modelName}.`,
+                            'error',
+                        );
+                        return;
+                    }
+                } catch {
+                    // Unreadable metadata locally — let the API validate the upload.
+                }
             }
 
             setIsGenerating(true);
@@ -497,80 +519,48 @@ export function useVideoGeneration({
             try {
                 console.log(`Input sent to API for model ${modelName}:`, input);
 
-                // Step 1: Submit the request and get request ID
-                const submitResult = await fal.queue.submit(modelId, {
-                    input: input,
+                const { data } = await submitAndPollFalQueue({
+                    modelId,
+                    input,
+                    onStatus: setStatus,
+                    pollInterval: POLL_INTERVAL_MS,
+                    shouldCancel: () => cancelledRef.current,
+                    timeoutMs: POLL_TIMEOUT_MS,
                 });
-                const requestId = submitResult.request_id;
-                console.log(`Request submitted successfully. Request ID: ${requestId}`);
-                setStatus(`Request submitted. Request ID: ${requestId}. Waiting for completion...`);
 
-                // Step 2: Poll status until not "IN_QUEUE" or "IN_PROGRESS"
-                const POLL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
-                const pollStart = Date.now();
+                // Video response can have different structures
+                let videoResultUrl: string | undefined;
 
-                while (!cancelledRef.current) {
-                    if (Date.now() - pollStart > POLL_TIMEOUT_MS) {
-                        setStatus('Video generation timed out after 10 minutes.', 'error');
-                        console.error(`Polling timed out for request ${requestId}`);
-                        break;
+                if (data.video) {
+                    if (typeof data.video === 'string') {
+                        videoResultUrl = data.video;
+                    } else if (typeof data.video === 'object' && data.video !== null) {
+                        const videoObj = data.video as { url?: string };
+                        videoResultUrl = videoObj.url;
                     }
+                } else if (Array.isArray(data.videos) && data.videos.length > 0) {
+                    const firstVideo = data.videos[0] as { url?: string } | string;
+                    videoResultUrl = typeof firstVideo === 'string' ? firstVideo : firstVideo.url;
+                }
 
-                    const statusResult = await fal.queue.status(modelId, {
-                        requestId,
-                        logs: true,
-                    });
-                    if (cancelledRef.current) break;
-
-                    console.log(`Status update for request ID ${requestId}:`, statusResult.status);
-                    if (statusResult.status === 'IN_QUEUE' || statusResult.status === 'IN_PROGRESS') {
-                        const logs = (statusResult as { logs?: Array<{ message: string }> }).logs;
-                        const latestLog = sanitizeLogMessage(logs?.length ? logs[logs.length - 1].message : '');
-                        setStatus(`Request is ${statusResult.status}: ${latestLog}`);
-                        console.log(
-                            `Status logs:`,
-                            logs?.map((log) => log.message),
-                        );
-                        await new Promise((resolve) => setTimeout(resolve, 3000)); // Longer poll interval for video
-                    } else if (statusResult.status === 'COMPLETED') {
-                        const result = await fal.queue.result(modelId, {
-                            requestId,
-                        });
-                        console.log(`Request completed. Full result:`, result);
-
-                        // Video response can have different structures
-                        const data = result.data as Record<string, unknown>;
-                        let videoResultUrl: string | undefined;
-
-                        if (data.video) {
-                            if (typeof data.video === 'string') {
-                                videoResultUrl = data.video;
-                            } else if (typeof data.video === 'object' && data.video !== null) {
-                                const videoObj = data.video as { url?: string };
-                                videoResultUrl = videoObj.url;
-                            }
-                        } else if (Array.isArray(data.videos) && data.videos.length > 0) {
-                            const firstVideo = data.videos[0] as { url?: string } | string;
-                            videoResultUrl = typeof firstVideo === 'string' ? firstVideo : firstVideo.url;
-                        }
-
-                        if (videoResultUrl) {
-                            console.log(`Video generated successfully:`, videoResultUrl);
-                            setVideoUrl(videoResultUrl);
-                            setStatus(`Video generated successfully using ${modelName}!`, 'success');
-                        } else {
-                            setStatus('Video generation failed. No video URL found in result.', 'error');
-                            console.error('No video URL in result:', result);
-                        }
-                        break;
-                    } else {
-                        const status = (statusResult as { status: string }).status;
-                        setStatus(`Request failed with status: ${status}`, 'error');
-                        console.error(`Request failed with status ${status}:`, statusResult);
-                        break;
-                    }
+                if (videoResultUrl) {
+                    console.log(`Video generated successfully:`, videoResultUrl);
+                    setVideoUrl(videoResultUrl);
+                    setStatus(`Video generated successfully using ${modelName}!`, 'success');
+                } else {
+                    setStatus('Video generation failed. No video URL found in result.', 'error');
+                    console.error('No video URL in result:', data);
                 }
             } catch (error: unknown) {
+                // Cancelled means the component unmounted — skip state updates.
+                if (error instanceof FalQueueCancelledError) {
+                    return;
+                }
+                if (error instanceof FalQueueTimeoutError) {
+                    setStatus('Video generation timed out after 10 minutes.', 'error');
+                    console.error('Video generation error:', error);
+                    return;
+                }
                 console.error('Video generation error:', error);
 
                 const parsedError = parseFalError(error);

--- a/src/hooks/useVideoGeneration.ts
+++ b/src/hooks/useVideoGeneration.ts
@@ -7,6 +7,7 @@ import { parseFalError } from '../services/errors';
 import { sanitizeLogMessage } from '../utils/logSanitizer';
 import { getImageInputConfig } from '../services/modelParams';
 import { activeLongDurationConstraint, getVideoCapabilityProfile } from '../services/videoModelCapabilities';
+import { getExtendCapabilityProfile } from '../services/extendVideoCapabilities';
 import { isSeedanceModel } from '../services/videoModels';
 import type { StatusType } from './useStatusMessage';
 
@@ -50,17 +51,23 @@ export function useVideoGeneration({
     const generateVideo = useCallback(
         async (prompt: string, model: ModelConfig) => {
             cancelledRef.current = false;
-            if (!prompt) {
-                setStatus('Please enter a text prompt.', 'error');
-                console.error('Prompt text is empty. Cannot generate video.');
-                return;
-            }
 
             const modelId = model.endpointId;
             const modelName = model.displayName;
             const isImageToVideo = activeTab === 'image-to-video';
             const isVideoToVideo = activeTab === 'video-to-video';
             const isReferenceToVideo = activeTab === 'reference-to-video';
+            const isExtendVideo = activeTab === 'extend-video';
+            const extendProfile = isExtendVideo ? getExtendCapabilityProfile(modelId) : undefined;
+
+            // Prompt is required everywhere except extend endpoints whose
+            // profile marks it optional (LTX 2.3 Pro extends without one).
+            const promptOptional = isExtendVideo && extendProfile !== undefined && !extendProfile.promptRequired;
+            if (!prompt && !promptOptional) {
+                setStatus('Please enter a text prompt.', 'error');
+                console.error('Prompt text is empty. Cannot generate video.');
+                return;
+            }
 
             // For image-to-video mode, require an uploaded image
             if (isImageToVideo && uploadedImages.length === 0) {
@@ -68,9 +75,9 @@ export function useVideoGeneration({
                 return;
             }
 
-            // For video-to-video mode, require an uploaded video
-            if (isVideoToVideo && !uploadedVideoFile) {
-                setStatus('Please upload a video for video-to-video generation.', 'error');
+            // For video-to-video and extend-video modes, require an uploaded video
+            if ((isVideoToVideo || isExtendVideo) && !uploadedVideoFile) {
+                setStatus('Please upload a video to extend or transform.', 'error');
                 return;
             }
 
@@ -135,8 +142,8 @@ export function useVideoGeneration({
                 }
             }
 
-            // For video-to-video, upload the video first
-            if (isVideoToVideo && uploadedVideoFile) {
+            // For video-to-video and extend-video, upload the video first
+            if ((isVideoToVideo || isExtendVideo) && uploadedVideoFile) {
                 try {
                     setStatus(`Uploading video for ${modelName}...`);
                     uploadedVideoUrl = await fal.storage.upload(uploadedVideoFile);
@@ -163,7 +170,59 @@ export function useVideoGeneration({
             // per-model conditionals. Unprofiled endpoints use the legacy branches.
             const profile = getVideoCapabilityProfile(modelId);
 
-            if (profile) {
+            if (isExtendVideo) {
+                // Extend endpoints take the source clip plus range/constraint
+                // parameters from the ExtendCapabilityProfile. Unprofiled extend
+                // endpoints get only prompt + video_url (server defaults apply).
+                input.video_url = uploadedVideoUrl;
+
+                // LTX 2.3 Pro accepts requests without a prompt; drop the empty field.
+                if (!prompt) {
+                    delete input.prompt;
+                }
+
+                if (extendProfile) {
+                    // Duration: FLUX defaults to "auto" (omit the field); LTX always
+                    // takes explicit float seconds. Whole-second endpoints get integers.
+                    const durationAuto = extendProfile.supportsAutoDuration && config.extendDurationAuto;
+                    if (!durationAuto) {
+                        const clamped = Math.min(
+                            Math.max(config.extendDuration, extendProfile.durationMin),
+                            extendProfile.durationMax,
+                        );
+                        input.duration = extendProfile.durationStep === 1 ? Math.round(clamped) : clamped;
+                    }
+
+                    if (extendProfile.supportsMode) {
+                        input.mode = config.extendMode === 'start' ? 'start' : 'end';
+                    }
+
+                    // Context: omitting the field maximizes available context server-side.
+                    if (extendProfile.supportsContext && !config.extendContextAuto) {
+                        input.context = Math.min(Math.max(config.extendContext, 1), 20);
+                    }
+
+                    if (extendProfile.resolutions.length > 0) {
+                        input.resolution = extendProfile.resolutions.includes(config.videoResolution)
+                            ? config.videoResolution
+                            : extendProfile.resolutions[0];
+                    }
+
+                    if (extendProfile.aspectRatios.length > 0) {
+                        input.aspect_ratio = extendProfile.aspectRatios.includes(config.extendAspectRatio)
+                            ? config.extendAspectRatio
+                            : extendProfile.aspectRatios[0];
+                    }
+
+                    if (extendProfile.supportsGenerateAudio) {
+                        input.generate_audio = config.generateAudio;
+                    }
+
+                    if (extendProfile.supportsSafetyTolerance) {
+                        input.safety_tolerance = Math.min(Math.max(config.extendSafetyTolerance, 0), 4);
+                    }
+                }
+            } else if (profile) {
                 if (config.videoResolution) {
                     input.resolution = config.videoResolution;
                 }
@@ -310,8 +369,9 @@ export function useVideoGeneration({
             }
 
             // Model detection for specific parameters (legacy routing — skipped for
-            // profiled endpoints and seedance, whose input shapes are built above).
-            if (!isSeedance && !profile) {
+            // extend mode, profiled endpoints, and seedance, whose input shapes are
+            // built above).
+            if (!isExtendVideo && !isSeedance && !profile) {
                 const isKlingModel = modelIdLower.includes('kling');
                 const isVeoModel = modelIdLower.includes('veo');
                 const isLtx19bModel = modelIdLower.includes('ltx-2-19b');

--- a/src/services/extendVideoCapabilities.test.ts
+++ b/src/services/extendVideoCapabilities.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { getExtendCapabilityProfile } from './extendVideoCapabilities';
+import { checkExtendSource, getExtendCapabilityProfile } from './extendVideoCapabilities';
+
+const sourceFile = (overrides: Partial<Pick<File, 'size' | 'type' | 'name'>> = {}) => ({
+    size: 1_000_000,
+    type: 'video/mp4',
+    name: 'clip.mp4',
+    ...overrides,
+});
 
 describe('getExtendCapabilityProfile', () => {
     describe('LTX 2.3 Pro extend', () => {
@@ -84,5 +91,83 @@ describe('getExtendCapabilityProfile', () => {
 
     it('matches endpoint IDs case-insensitively', () => {
         expect(getExtendCapabilityProfile('Blackforestlabs/FLUX-3/Extend-Video')).toBeDefined();
+    });
+
+    it('declares the client-checkable source file constraints', () => {
+        // FLUX standard: MP4 under 50 MB; draft: MP4 up to 50 MiB.
+        const standard = getExtendCapabilityProfile('blackforestlabs/flux-3/extend-video');
+        expect(standard?.sourceMaxBytes).toBe(50_000_000);
+        expect(standard?.sourceMimeTypes).toEqual(['video/mp4']);
+        const draft = getExtendCapabilityProfile('blackforestlabs/flux-3/extend-video/draft');
+        expect(draft?.sourceMaxBytes).toBe(50 * 1024 * 1024);
+        expect(draft?.sourceMimeTypes).toEqual(['video/mp4']);
+
+        // LTX 2.3 Pro: no file-level constraints documented.
+        const ltx = getExtendCapabilityProfile('fal-ai/ltx-2.3/extend-video');
+        expect(ltx?.sourceMaxBytes).toBeNull();
+        expect(ltx?.sourceMimeTypes).toEqual([]);
+    });
+});
+
+describe('checkExtendSource', () => {
+    const flux = getExtendCapabilityProfile('blackforestlabs/flux-3/extend-video')!;
+    const draft = getExtendCapabilityProfile('blackforestlabs/flux-3/extend-video/draft')!;
+    const ltx = getExtendCapabilityProfile('fal-ai/ltx-2.3/extend-video')!;
+
+    it('accepts an MP4 within all bounds', () => {
+        const check = checkExtendSource(flux, sourceFile(), 8);
+        expect(check).toEqual({
+            tooLong: false,
+            tooLarge: false,
+            wrongContainer: false,
+            blocked: false,
+            accepted: true,
+        });
+    });
+
+    it('flags sources over the duration ceiling', () => {
+        expect(checkExtendSource(flux, sourceFile(), 16)).toMatchObject({ tooLong: true, blocked: true });
+        // Draft has no duration ceiling.
+        expect(checkExtendSource(draft, sourceFile(), 16).tooLong).toBe(false);
+    });
+
+    it('rejects non-MP4 containers when the profile requires MP4', () => {
+        const webm = checkExtendSource(flux, sourceFile({ type: 'video/webm', name: 'clip.webm' }), 8);
+        expect(webm).toMatchObject({ wrongContainer: true, blocked: true, accepted: false });
+        // Unconstrained profiles accept any container.
+        expect(checkExtendSource(ltx, sourceFile({ type: 'video/webm', name: 'clip.webm' }), 8).blocked).toBe(false);
+    });
+
+    it('accepts MP4s reported under noncanonical or empty MIME types', () => {
+        // Browsers/OSes report legitimate .mp4 files as application/mp4,
+        // application/octet-stream, or "" — the extension must rescue them.
+        expect(checkExtendSource(flux, sourceFile({ type: 'application/mp4' }), 8).wrongContainer).toBe(false);
+        expect(checkExtendSource(flux, sourceFile({ type: 'application/octet-stream' }), 8).wrongContainer).toBe(false);
+        expect(checkExtendSource(flux, sourceFile({ type: '' }), 8).wrongContainer).toBe(false);
+        // Neither MIME nor extension matching still fails.
+        expect(checkExtendSource(flux, sourceFile({ type: '', name: 'clip.avi' }), 8).wrongContainer).toBe(true);
+        expect(
+            checkExtendSource(flux, sourceFile({ type: 'application/octet-stream', name: 'clip' }), 8).wrongContainer,
+        ).toBe(true);
+    });
+
+    it('flags files over the size limit', () => {
+        expect(checkExtendSource(flux, sourceFile({ size: 50_000_001 }), 8)).toMatchObject({
+            tooLarge: true,
+            blocked: true,
+        });
+        expect(checkExtendSource(flux, sourceFile({ size: 50_000_000 }), 8).tooLarge).toBe(false);
+        // Draft's ceiling is 50 MiB, not 50 MB.
+        expect(checkExtendSource(draft, sourceFile({ size: 50 * 1024 * 1024 + 1 }), 8).tooLarge).toBe(true);
+        expect(checkExtendSource(draft, sourceFile({ size: 50_000_001 }), 8).tooLarge).toBe(false);
+    });
+
+    it('treats an unknown duration as neither accepted nor blocked on duration', () => {
+        const check = checkExtendSource(flux, sourceFile(), null);
+        expect(check.tooLong).toBe(false);
+        expect(check.accepted).toBe(false);
+        expect(check.blocked).toBe(false);
+        // File-level violations still block even with unknown duration.
+        expect(checkExtendSource(flux, sourceFile({ type: 'video/webm', name: 'c.webm' }), null).blocked).toBe(true);
     });
 });

--- a/src/services/extendVideoCapabilities.test.ts
+++ b/src/services/extendVideoCapabilities.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { getExtendCapabilityProfile } from './extendVideoCapabilities';
+
+describe('getExtendCapabilityProfile', () => {
+    describe('LTX 2.3 Pro extend', () => {
+        it('declares float duration 2-20 with mode and context, nothing else', () => {
+            const profile = getExtendCapabilityProfile('fal-ai/ltx-2.3/extend-video');
+            expect(profile).toBeDefined();
+
+            expect(profile?.durationMin).toBe(2);
+            expect(profile?.durationMax).toBe(20);
+            expect(profile?.durationStep).toBe(0.5);
+            expect(profile?.supportsAutoDuration).toBe(false);
+
+            // Start/end extension and a 1-20s context window
+            expect(profile?.supportsMode).toBe(true);
+            expect(profile?.supportsContext).toBe(true);
+
+            // No resolution/aspect/audio/safety inputs; prompt is optional
+            expect(profile?.resolutions).toEqual([]);
+            expect(profile?.aspectRatios).toEqual([]);
+            expect(profile?.supportsGenerateAudio).toBe(false);
+            expect(profile?.supportsSafetyTolerance).toBe(false);
+            expect(profile?.promptRequired).toBe(false);
+
+            expect(profile?.sourceMaxSeconds).toBeNull();
+            expect(profile?.isDraft).toBe(false);
+        });
+    });
+
+    describe('FLUX 3 extend', () => {
+        it.each(['blackforestlabs/flux-3/extend-video', 'blackforestlabs/flux-3/extend-video/draft'])(
+            '%s declares whole-second auto-default duration and required prompt',
+            (endpointId) => {
+                const profile = getExtendCapabilityProfile(endpointId);
+                expect(profile).toBeDefined();
+
+                // Whole seconds 5-20, defaulting to "auto" (field omitted)
+                expect(profile?.durationMin).toBe(5);
+                expect(profile?.durationMax).toBe(20);
+                expect(profile?.durationStep).toBe(1);
+                expect(profile?.supportsAutoDuration).toBe(true);
+
+                // End-only extension, no context concept
+                expect(profile?.supportsMode).toBe(false);
+                expect(profile?.supportsContext).toBe(false);
+
+                // Aspect enum includes 2:1 (and not 9:21); audio and safety tolerance exist
+                expect(profile?.aspectRatios).toEqual(['auto', '21:9', '2:1', '16:9', '4:3', '1:1', '3:4', '9:16']);
+                expect(profile?.supportsGenerateAudio).toBe(true);
+                expect(profile?.supportsSafetyTolerance).toBe(true);
+                expect(profile?.promptRequired).toBe(true);
+            },
+        );
+
+        it('standard tier has 720p/1080p and a 15s source ceiling; draft has neither', () => {
+            const standard = getExtendCapabilityProfile('blackforestlabs/flux-3/extend-video');
+            expect(standard?.resolutions).toEqual(['720p', '1080p']);
+            expect(standard?.sourceMaxSeconds).toBe(15);
+            expect(standard?.isDraft).toBe(false);
+
+            // Draft is 720p-only (no resolution input) with no stated source
+            // duration cap, and returns a draft_cache for draft-enhance.
+            const draft = getExtendCapabilityProfile('blackforestlabs/flux-3/extend-video/draft');
+            expect(draft?.resolutions).toEqual([]);
+            expect(draft?.sourceMaxSeconds).toBeNull();
+            expect(draft?.isDraft).toBe(true);
+        });
+    });
+
+    describe('unprofiled extend endpoints', () => {
+        it.each([
+            // Frame-based LTX variants and later stack layers (grok, veo) are deferred.
+            'fal-ai/ltx-2.3-quality/extend-video',
+            'fal-ai/ltx-2.3-22b/extend-video',
+            'xai/grok-imagine-video/extend-video',
+            'fal-ai/veo3.1/extend-video',
+            'fal-ai/veo3.1/fast/extend-video',
+            'fal-ai/ltx-2.3/retake-video',
+        ])('%s has no profile yet', (endpointId) => {
+            expect(getExtendCapabilityProfile(endpointId)).toBeUndefined();
+        });
+    });
+
+    it('matches endpoint IDs case-insensitively', () => {
+        expect(getExtendCapabilityProfile('Blackforestlabs/FLUX-3/Extend-Video')).toBeDefined();
+    });
+});

--- a/src/services/extendVideoCapabilities.ts
+++ b/src/services/extendVideoCapabilities.ts
@@ -42,6 +42,14 @@ export interface ExtendCapabilityProfile {
     promptRequired: boolean;
     /** Maximum source clip length in seconds, or null when unconstrained. */
     sourceMaxSeconds: number | null;
+    /** Maximum source file size in bytes, or null when the docs state none. */
+    sourceMaxBytes: number | null;
+    /**
+     * Accepted source container MIME types (e.g. ['video/mp4']); empty =
+     * unconstrained. Codec requirements inside a container can't be checked
+     * client-side — the API stays the final validator there.
+     */
+    sourceMimeTypes: string[];
     /** Draft tier: 720p-only preview that also returns a reusable draft_cache. */
     isDraft: boolean;
 }
@@ -68,6 +76,8 @@ function flux3ExtendProfile(overrides: Partial<ExtendCapabilityProfile>): Extend
         supportsSafetyTolerance: true,
         promptRequired: true,
         sourceMaxSeconds: 15,
+        sourceMaxBytes: 50_000_000,
+        sourceMimeTypes: ['video/mp4'],
         isDraft: false,
         ...overrides,
     };
@@ -89,6 +99,8 @@ const PROFILES: Record<string, ExtendCapabilityProfile> = {
         supportsSafetyTolerance: false,
         promptRequired: false,
         sourceMaxSeconds: null,
+        sourceMaxBytes: null,
+        sourceMimeTypes: [],
         isDraft: false,
     },
     // Source clip: MP4, under 50 MB and under 15 seconds.
@@ -98,6 +110,7 @@ const PROFILES: Record<string, ExtendCapabilityProfile> = {
     'blackforestlabs/flux-3/extend-video/draft': flux3ExtendProfile({
         resolutions: [],
         sourceMaxSeconds: null,
+        sourceMaxBytes: 50 * 1024 * 1024,
         isDraft: true,
     }),
     // fal-ai/ltx-2.3-quality and ltx-2.3-22b extend are frame-based APIs
@@ -111,4 +124,68 @@ const PROFILES: Record<string, ExtendCapabilityProfile> = {
  */
 export function getExtendCapabilityProfile(endpointId: string): ExtendCapabilityProfile | undefined {
     return PROFILES[endpointId.toLowerCase()];
+}
+
+/**
+ * Canonical MIME type → accepted aliases and file extensions. Browsers and
+ * OSes report legitimate files under noncanonical or empty MIME types
+ * (application/mp4, application/octet-stream, ""), so a file passes when
+ * either its MIME type or its extension matches — the same policy the
+ * upload zone applies.
+ */
+const CONTAINER_MATCHERS: Record<string, { mimeTypes: string[]; extensions: string[] }> = {
+    'video/mp4': { mimeTypes: ['video/mp4', 'application/mp4'], extensions: ['.mp4'] },
+};
+
+function matchesContainer(file: Pick<File, 'type' | 'name'>, required: string[]): boolean {
+    const type = file.type.toLowerCase();
+    const name = file.name.toLowerCase();
+    return required.some((mime) => {
+        const matcher = CONTAINER_MATCHERS[mime] ?? { mimeTypes: [mime], extensions: [] };
+        return matcher.mimeTypes.includes(type) || matcher.extensions.some((ext) => name.endsWith(ext));
+    });
+}
+
+export interface ExtendSourceCheck {
+    tooLong: boolean;
+    tooLarge: boolean;
+    wrongContainer: boolean;
+    /** Any hard violation — generation should be blocked. */
+    blocked: boolean;
+    /**
+     * Duration is known and every client-checkable constraint passes.
+     * Not the negation of `blocked`: an unknown duration is neither.
+     */
+    accepted: boolean;
+}
+
+/**
+ * Validate a source clip against everything the profile can check
+ * client-side: duration ceiling (when known), file size, and container.
+ * Codecs are not inspected — the API remains the final validator there.
+ * Shared by the chips, the Generate gating, and the hook's pre-upload check
+ * so the three never disagree.
+ */
+export function checkExtendSource(
+    profile: ExtendCapabilityProfile,
+    file: Pick<File, 'size' | 'type' | 'name'>,
+    durationSeconds: number | null,
+): ExtendSourceCheck {
+    const tooLong =
+        profile.sourceMaxSeconds !== null && durationSeconds !== null && durationSeconds > profile.sourceMaxSeconds;
+    const tooLarge = profile.sourceMaxBytes !== null && file.size > profile.sourceMaxBytes;
+    const wrongContainer = profile.sourceMimeTypes.length > 0 && !matchesContainer(file, profile.sourceMimeTypes);
+    const blocked = tooLong || tooLarge || wrongContainer;
+    return {
+        tooLong,
+        tooLarge,
+        wrongContainer,
+        blocked,
+        accepted: durationSeconds !== null && !blocked,
+    };
+}
+
+/** Human label for a source size limit, honoring the unit the docs use. */
+export function formatSourceMaxBytes(bytes: number): string {
+    return bytes % (1024 * 1024) === 0 ? `${bytes / (1024 * 1024)} MiB` : `${bytes / 1_000_000} MB`;
 }

--- a/src/services/extendVideoCapabilities.ts
+++ b/src/services/extendVideoCapabilities.ts
@@ -1,0 +1,114 @@
+/**
+ * Endpoint capability profiles for extend-video models.
+ *
+ * Extend endpoints continue an existing clip, so their capabilities are
+ * ranges and constraints (duration min/max, source ceiling, has-mode,
+ * has-context) rather than the plain enums of `VideoCapabilityProfile` —
+ * hence a separate profile shape. Same conventions otherwise: keyed by
+ * exact endpoint ID, empty array = the input doesn't exist, `undefined`
+ * lookup = unprofiled endpoint (send only prompt + video_url).
+ *
+ * Schema source of truth: https://fal.ai/models/<endpoint-id>/llms.txt
+ */
+
+export interface ExtendCapabilityProfile {
+    /** Extension length bounds in seconds. */
+    durationMin: number;
+    durationMax: number;
+    /** Slider step; also implies the wire format (1 = whole seconds, 0.5 = float). */
+    durationStep: number;
+    /**
+     * Whether the schema accepts `duration: "auto"` and defaults to it
+     * (FLUX 3). When true the UI offers Auto/Manual; auto omits the field.
+     */
+    supportsAutoDuration: boolean;
+    /** Whether the schema has `mode: 'start' | 'end'` (LTX 2.3). */
+    supportsMode: boolean;
+    /**
+     * Whether the schema has `context` (seconds of source the model
+     * conditions on, 1-20). Omitting the field maximizes available context,
+     * so the UI defaults to an "auto" state that sends nothing.
+     */
+    supportsContext: boolean;
+    /** `resolution` enum values; first entry is the default. Empty = no such input. */
+    resolutions: string[];
+    /** `aspect_ratio` enum values; first entry is the default. Empty = no such input. */
+    aspectRatios: string[];
+    /** Whether the input schema has `generate_audio`. */
+    supportsGenerateAudio: boolean;
+    /** Whether the input schema has integer `safety_tolerance` (0-4, default 2). */
+    supportsSafetyTolerance: boolean;
+    /** Whether `prompt` is required (FLUX) or optional (LTX 2.3 Pro). */
+    promptRequired: boolean;
+    /** Maximum source clip length in seconds, or null when unconstrained. */
+    sourceMaxSeconds: number | null;
+    /** Draft tier: 720p-only preview that also returns a reusable draft_cache. */
+    isDraft: boolean;
+}
+
+const FLUX_3_EXTEND_ASPECT_RATIOS = ['auto', '21:9', '2:1', '16:9', '4:3', '1:1', '3:4', '9:16'];
+
+/**
+ * Shared FLUX 3 extend schema: whole-second duration enum 5-20 defaulting to
+ * "auto", required prompt, end-only extension, generate_audio and
+ * safety_tolerance. The draft tier drops `resolution` (720p only) and
+ * additionally returns a `draft_cache` for the draft-enhance workflow.
+ */
+function flux3ExtendProfile(overrides: Partial<ExtendCapabilityProfile>): ExtendCapabilityProfile {
+    return {
+        durationMin: 5,
+        durationMax: 20,
+        durationStep: 1,
+        supportsAutoDuration: true,
+        supportsMode: false,
+        supportsContext: false,
+        resolutions: ['720p', '1080p'],
+        aspectRatios: FLUX_3_EXTEND_ASPECT_RATIOS,
+        supportsGenerateAudio: true,
+        supportsSafetyTolerance: true,
+        promptRequired: true,
+        sourceMaxSeconds: 15,
+        isDraft: false,
+        ...overrides,
+    };
+}
+
+const PROFILES: Record<string, ExtendCapabilityProfile> = {
+    // LTX 2.3 Pro: float duration 2-20 (default 5), start/end mode, optional
+    // context 1-20s. No resolution/aspect/audio/seed inputs; prompt optional.
+    'fal-ai/ltx-2.3/extend-video': {
+        durationMin: 2,
+        durationMax: 20,
+        durationStep: 0.5,
+        supportsAutoDuration: false,
+        supportsMode: true,
+        supportsContext: true,
+        resolutions: [],
+        aspectRatios: [],
+        supportsGenerateAudio: false,
+        supportsSafetyTolerance: false,
+        promptRequired: false,
+        sourceMaxSeconds: null,
+        isDraft: false,
+    },
+    // Source clip: MP4, under 50 MB and under 15 seconds.
+    'blackforestlabs/flux-3/extend-video': flux3ExtendProfile({}),
+    // Draft: no resolution input; source limit is 50 MiB with no stated
+    // duration cap; returns draft_cache alongside the video.
+    'blackforestlabs/flux-3/extend-video/draft': flux3ExtendProfile({
+        resolutions: [],
+        sourceMaxSeconds: null,
+        isDraft: true,
+    }),
+    // fal-ai/ltx-2.3-quality and ltx-2.3-22b extend are frame-based APIs
+    // (num_frames/num_context_frames, 19B-style knobs) — deferred.
+    // xai/grok-imagine-video and fal-ai/veo3.1 extend land in later stack layers.
+};
+
+/**
+ * Look up the extend capability profile for an endpoint.
+ * Returns undefined for unprofiled endpoints (minimal prompt + video_url payload).
+ */
+export function getExtendCapabilityProfile(endpointId: string): ExtendCapabilityProfile | undefined {
+    return PROFILES[endpointId.toLowerCase()];
+}

--- a/src/services/falQueue.ts
+++ b/src/services/falQueue.ts
@@ -6,10 +6,33 @@ export interface FalQueueOptions {
     input: Record<string, unknown>;
     onStatus: (message: string) => void;
     pollInterval?: number;
+    /**
+     * Checked before and after each status poll; returning true aborts with
+     * FalQueueCancelledError (e.g. the calling component unmounted).
+     */
+    shouldCancel?: () => boolean;
+    /** Overall deadline; exceeding it aborts with FalQueueTimeoutError. */
+    timeoutMs?: number;
 }
 
 export interface FalQueueResult {
     data: Record<string, unknown>;
+}
+
+/** Polling was abandoned because the caller cancelled (not an API failure). */
+export class FalQueueCancelledError extends Error {
+    constructor() {
+        super('Request cancelled');
+        this.name = 'FalQueueCancelledError';
+    }
+}
+
+/** The request did not complete within `timeoutMs`. */
+export class FalQueueTimeoutError extends Error {
+    constructor(timeoutMs: number) {
+        super(`Request timed out after ${Math.round(timeoutMs / 60000)} minutes.`);
+        this.name = 'FalQueueTimeoutError';
+    }
 }
 
 export async function submitAndPollFalQueue({
@@ -17,17 +40,31 @@ export async function submitAndPollFalQueue({
     input,
     onStatus,
     pollInterval = 2000,
+    shouldCancel,
+    timeoutMs,
 }: FalQueueOptions): Promise<FalQueueResult> {
     const submitResult = await fal.queue.submit(modelId, { input });
     const requestId = submitResult.request_id;
     console.log(`Request submitted. Request ID: ${requestId}`);
     onStatus(`Request submitted. Request ID: ${requestId}. Waiting for completion...`);
 
+    const startedAt = Date.now();
+
     while (true) {
+        if (shouldCancel?.()) {
+            throw new FalQueueCancelledError();
+        }
+        if (timeoutMs !== undefined && Date.now() - startedAt > timeoutMs) {
+            throw new FalQueueTimeoutError(timeoutMs);
+        }
+
         const statusResult = await fal.queue.status(modelId, {
             requestId,
             logs: true,
         });
+        if (shouldCancel?.()) {
+            throw new FalQueueCancelledError();
+        }
         console.log(`Status update for request ID ${requestId}:`, statusResult.status);
 
         if (statusResult.status === 'IN_QUEUE' || statusResult.status === 'IN_PROGRESS') {

--- a/src/services/videoModels.ts
+++ b/src/services/videoModels.ts
@@ -445,12 +445,44 @@ export const CURATED_VIDEO_TO_VIDEO_MODELS: ModelConfig[] = [
     },
 ];
 
+/**
+ * Curated list of extend-video models (continue an existing clip).
+ * Capabilities per endpoint live in `services/extendVideoCapabilities.ts`.
+ */
+export const CURATED_EXTEND_VIDEO_MODELS: ModelConfig[] = [
+    {
+        endpointId: 'fal-ai/ltx-2.3/extend-video',
+        displayName: 'LTX-2.3 Extend',
+        category: 'extend-video',
+        description: 'Extend a clip at either end, 2-20s per pass with context control',
+        supportsImageInput: false,
+        outputType: 'video',
+    },
+    {
+        endpointId: 'blackforestlabs/flux-3/extend-video',
+        displayName: 'FLUX 3 Extend',
+        category: 'extend-video',
+        description: 'Continue a clip past its final frame with audio, source up to 15s',
+        supportsImageInput: false,
+        outputType: 'video',
+    },
+    {
+        endpointId: 'blackforestlabs/flux-3/extend-video/draft',
+        displayName: 'FLUX 3 Extend Draft',
+        category: 'extend-video',
+        description: 'Fast low-cost 720p extend preview with a reusable draft cache',
+        supportsImageInput: false,
+        outputType: 'video',
+    },
+];
+
 /** All curated video models */
 export const CURATED_VIDEO_MODELS: ModelConfig[] = [
     ...CURATED_TEXT_TO_VIDEO_MODELS,
     ...CURATED_IMAGE_TO_VIDEO_MODELS,
     ...CURATED_VIDEO_TO_VIDEO_MODELS,
     ...CURATED_REFERENCE_TO_VIDEO_MODELS,
+    ...CURATED_EXTEND_VIDEO_MODELS,
 ];
 
 /**
@@ -475,6 +507,10 @@ export function getCuratedVideoModels(category?: VideoModelCategory): ModelConfi
 
     if (category === 'reference-to-video') {
         return CURATED_REFERENCE_TO_VIDEO_MODELS;
+    }
+
+    if (category === 'extend-video') {
+        return CURATED_EXTEND_VIDEO_MODELS;
     }
 
     return [];

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -7,7 +7,12 @@
 export type ImageModelCategory = 'text-to-image' | 'image-to-image';
 
 /** Model categories for video generation */
-export type VideoModelCategory = 'text-to-video' | 'image-to-video' | 'video-to-video' | 'reference-to-video';
+export type VideoModelCategory =
+    | 'text-to-video'
+    | 'image-to-video'
+    | 'video-to-video'
+    | 'reference-to-video'
+    | 'extend-video';
 
 /** Model categories for audio generation */
 export type AudioModelCategory =
@@ -101,7 +106,8 @@ function getOutputType(category: ModelCategory): OutputType {
         category === 'text-to-video' ||
         category === 'image-to-video' ||
         category === 'video-to-video' ||
-        category === 'reference-to-video'
+        category === 'reference-to-video' ||
+        category === 'extend-video'
     ) {
         return 'video';
     }
@@ -126,7 +132,7 @@ function getSupportsImageInput(category: ModelCategory): boolean {
 
 /** Determine if model supports video input based on category */
 export function getSupportsVideoInput(category: ModelCategory): boolean {
-    return category === 'video-to-video' || category === 'video-to-audio';
+    return category === 'video-to-video' || category === 'video-to-audio' || category === 'extend-video';
 }
 
 /** Determine if model supports audio input based on category */
@@ -141,10 +147,15 @@ export function normalizeModel(model: FalModel): ModelConfig {
     // under metadata.category === 'image-to-video'. Detect them by endpoint suffix
     // so they route through the dedicated R2V picker and the R2V branch of
     // useVideoGeneration (`image_urls` array) instead of the I2V branch (`image_url`).
+    // Extend endpoints are filed under category === 'video-to-video' in the
+    // catalog; detect them by path segment (covers `/extend-video` and tier
+    // suffixes like `/extend-video/draft`) so they route to the extend mode.
     const endpointIdLower = model.endpoint_id.toLowerCase();
     const category: ModelCategory = endpointIdLower.endsWith('/reference-to-video')
         ? 'reference-to-video'
-        : metadata.category || 'text-to-image';
+        : endpointIdLower.includes('/extend-video')
+          ? 'extend-video'
+          : metadata.category || 'text-to-image';
 
     return {
         endpointId: model.endpoint_id,

--- a/src/utils/videoMetadata.ts
+++ b/src/utils/videoMetadata.ts
@@ -1,0 +1,75 @@
+/**
+ * Probe an uploaded video file for metadata the extend-video UI needs:
+ * duration/dimensions (from a detached <video> element) and a poster frame
+ * (first frame drawn to a canvas). Runs entirely client-side on the local
+ * File — nothing is uploaded.
+ */
+
+export interface VideoFileMetadata {
+    /** Duration in seconds (may be fractional). */
+    duration: number;
+    width: number;
+    height: number;
+    /** Data URL of the first frame, or null when the codec blocks canvas capture. */
+    posterUrl: string | null;
+}
+
+/** Capture the current frame of a video element as a JPEG data URL. */
+function captureFrame(video: HTMLVideoElement): string | null {
+    try {
+        const canvas = document.createElement('canvas');
+        canvas.width = video.videoWidth;
+        canvas.height = video.videoHeight;
+        const ctx = canvas.getContext('2d');
+        if (!ctx || canvas.width === 0 || canvas.height === 0) {
+            return null;
+        }
+        ctx.drawImage(video, 0, 0);
+        return canvas.toDataURL('image/jpeg', 0.7);
+    } catch {
+        // Tainted canvas or unsupported codec — poster is optional.
+        return null;
+    }
+}
+
+export function probeVideoFile(file: File): Promise<VideoFileMetadata> {
+    return new Promise((resolve, reject) => {
+        const objectUrl = URL.createObjectURL(file);
+        const video = document.createElement('video');
+        video.preload = 'auto';
+        video.muted = true;
+
+        const cleanup = () => {
+            video.removeAttribute('src');
+            video.load();
+            URL.revokeObjectURL(objectUrl);
+        };
+
+        video.addEventListener('error', () => {
+            cleanup();
+            reject(new Error('Could not read video metadata from the selected file.'));
+        });
+
+        video.addEventListener('loadedmetadata', () => {
+            const { videoWidth, videoHeight } = video;
+            const finish = () => {
+                // Re-read after seeking: Chrome reports Infinity for
+                // MediaRecorder-produced webm until forced past the end.
+                const duration = video.duration;
+                const posterUrl = captureFrame(video);
+                cleanup();
+                if (!Number.isFinite(duration) || duration <= 0) {
+                    reject(new Error('Could not determine the video duration.'));
+                    return;
+                }
+                resolve({ duration, width: videoWidth, height: videoHeight, posterUrl });
+            };
+            video.addEventListener('seeked', finish, { once: true });
+            // Non-finite duration: seek far past the end so the browser
+            // computes the real duration; otherwise grab an early frame.
+            video.currentTime = Number.isFinite(video.duration) ? Math.min(0.1, video.duration / 2) : 1e10;
+        });
+
+        video.src = objectUrl;
+    });
+}


### PR DESCRIPTION
New `extend-video` generation mode (sidebar item under Generate Video)
that continues an uploaded clip past its final frame, following the
reviewed Claude Design timeline:

- ExtendCapabilityProfile (services/extendVideoCapabilities.ts): extend
  capabilities are ranges/constraints rather than enums — duration
  min/max/step, auto-duration, start/end mode, context window, source
  ceiling, prompt requirement — keyed by exact endpoint ID with
  undefined = unprofiled (minimal prompt + video_url payload).
- Profiles: fal-ai/ltx-2.3/extend-video (float 2-20s, mode, context
  omitted = maximize, prompt optional, no resolution/audio/seed),
  blackforestlabs/flux-3/extend-video (whole seconds 5-20 defaulting to
  auto, 15s/50MB source limit, resolution, aspect incl. 2:1, audio,
  safety_tolerance 0-4, prompt required) and its /draft tier (720p-only,
  no source-duration cap, returns a reusable draft_cache).
- ExtendVideoOptions + ExtendTimeline: source chips (duration/dims/size
  probed client-side), poster-frame strip, hatched extendable band with
  drag-to-set length, context overlay, Auto/Manual duration, auto-omit
  context, per-profile selects, source-ceiling warnings.
- utils/videoMetadata.ts: probe duration/dimensions/poster from the
  local file; handles Chrome's Infinity-duration MediaRecorder webm by
  seeking past the end (an unguarded Infinity span previously drove the
  tick loop unbounded — now also guarded in the timeline).
- Hook: extend branch builds the payload from the profile; prompt
  validation waived when the profile marks it optional; extend skips all
  legacy video branches. Catalog extend endpoints (category
  video-to-video upstream) are recategorized by /extend-video path
  segment and seeded from the curated list under "Show all models".

Deferred for later stack layers: xai/grok-imagine-video and fal-ai/veo3.1
extend, plus the frame-based ltx-2.3-quality/-22b variants and
draft-enhance re-rendering.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>