### PR TITLE
feat(video): add Grok Imagine extend via capability profile

### DIFF
--- a/src/components/ExtendVideoOptions.tsx
+++ b/src/components/ExtendVideoOptions.tsx
@@ -70,6 +70,8 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
     // One predicate for duration, size, and container — the same check gates
     // Generate in InputSection, so chips and button state always agree.
     const srcCheck = checkExtendSource(profile, videoFile, srcDuration);
+    const srcTooShort =
+        profile.sourceMinSeconds !== null && srcDuration !== null && srcDuration < profile.sourceMinSeconds;
     const totalSec = srcDuration !== null ? srcDuration + effectiveExt : null;
     const resultOverCeiling =
         profile.sourceMaxSeconds !== null && totalSec !== null && totalSec > profile.sourceMaxSeconds;
@@ -120,15 +122,23 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
                     <span className="extend-chip accent">
                         Extendable up to&nbsp;<strong>{profile.durationMax}s</strong>&nbsp;per pass
                     </span>
-                    {srcCheck.accepted && (
+                    {srcCheck.accepted && !srcTooShort && (
                         <span className="extend-chip success">
-                            &#10003; Source accepted by {selectedModel.displayName}
+                            &#10003;{' '}
+                            {profile.sourceNote
+                                ? `Source accepted — ${profile.sourceNote}`
+                                : `Source accepted by ${selectedModel.displayName}`}
                         </span>
                     )}
                     {srcCheck.tooLong && (
                         <span className="extend-chip warning">
                             &#9888; Source over the {profile.sourceMaxSeconds}s limit for this model &mdash; trim the
                             clip to extend it
+                        </span>
+                    )}
+                    {srcTooShort && (
+                        <span className="extend-chip warning">
+                            &#9888; Source under the {profile.sourceMinSeconds}s minimum for this model
                         </span>
                     )}
                     {srcCheck.tooLarge && profile.sourceMaxBytes !== null && (

--- a/src/components/ExtendVideoOptions.tsx
+++ b/src/components/ExtendVideoOptions.tsx
@@ -13,6 +13,7 @@ import {
     checkExtendSource,
     formatSourceMaxBytes,
     getExtendCapabilityProfile,
+    snapExtendDuration,
 } from '../services/extendVideoCapabilities';
 import type { VideoFileMetadata } from '../utils/videoMetadata';
 import type { ModelConfig } from '../types/models';
@@ -32,12 +33,14 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
     const config = useConfig();
     const profile = getExtendCapabilityProfile(selectedModel.endpointId);
 
-    // Clamp the stored extension length into the selected model's bounds.
+    // Clamp the stored extension length into the selected model's bounds and
+    // snap it to the model's step (a fractional LTX value like 2.5 must not
+    // survive into a whole-second model, where it would display 2.5 but send 3).
     useEffect(() => {
         if (!profile) return;
-        const clamped = Math.min(Math.max(config.extendDuration, profile.durationMin), profile.durationMax);
-        if (clamped !== config.extendDuration) {
-            config.setExtendDuration(clamped);
+        const snapped = snapExtendDuration(profile, config.extendDuration);
+        if (snapped !== config.extendDuration) {
+            config.setExtendDuration(snapped);
         }
         // Reset resolution/aspect to the profile default when the stored value is invalid.
         if (profile.resolutions.length > 0 && !profile.resolutions.includes(config.videoResolution)) {
@@ -62,7 +65,7 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
     const durationAuto = profile.supportsAutoDuration && config.extendDurationAuto;
     const contextAuto = !profile.supportsContext || config.extendContextAuto;
     const mode = profile.supportsMode && config.extendMode === 'start' ? 'start' : 'end';
-    const extSec = Math.min(Math.max(config.extendDuration, profile.durationMin), profile.durationMax);
+    const extSec = snapExtendDuration(profile, config.extendDuration);
     const effectiveExt = durationAuto ? profile.durationMax : extSec;
 
     // Guard against degenerate metadata (e.g. streams with unknown duration).
@@ -70,8 +73,6 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
     // One predicate for duration, size, and container — the same check gates
     // Generate in InputSection, so chips and button state always agree.
     const srcCheck = checkExtendSource(profile, videoFile, srcDuration);
-    const srcTooShort =
-        profile.sourceMinSeconds !== null && srcDuration !== null && srcDuration < profile.sourceMinSeconds;
     const totalSec = srcDuration !== null ? srcDuration + effectiveExt : null;
     const resultOverCeiling =
         profile.sourceMaxSeconds !== null && totalSec !== null && totalSec > profile.sourceMaxSeconds;
@@ -122,7 +123,7 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
                     <span className="extend-chip accent">
                         Extendable up to&nbsp;<strong>{profile.durationMax}s</strong>&nbsp;per pass
                     </span>
-                    {srcCheck.accepted && !srcTooShort && (
+                    {srcCheck.accepted && (
                         <span className="extend-chip success">
                             &#10003;{' '}
                             {profile.sourceNote
@@ -136,7 +137,7 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
                             clip to extend it
                         </span>
                     )}
-                    {srcTooShort && (
+                    {srcCheck.tooShort && (
                         <span className="extend-chip warning">
                             &#9888; Source under the {profile.sourceMinSeconds}s minimum for this model
                         </span>

--- a/src/components/InputSection.tsx
+++ b/src/components/InputSection.tsx
@@ -107,7 +107,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
     const extendPromptMissing = isExtendVideo && !extendPromptOptional && !promptText.trim();
 
     // Probe the source clip once here (shared with ExtendVideoOptions below)
-    // so a clip violating the model's source constraints (duration ceiling,
+    // so a clip violating the model's source constraints (duration bounds,
     // file size, container) disables Generate instead of only warning.
     // Unknown metadata doesn't block — the hook revalidates before upload.
     const extendVideoMeta = useVideoFileMetadata(isExtendVideo ? uploadedVideoFile : null);
@@ -116,6 +116,12 @@ export const InputSection: React.FC<InputSectionProps> = ({
         extendProfile !== undefined &&
         uploadedVideoFile !== null &&
         checkExtendSource(extendProfile, uploadedVideoFile, extendVideoMeta?.duration ?? null).blocked;
+    const extendSourceTooShort =
+        isExtendVideo &&
+        extendProfile !== undefined &&
+        extendProfile.sourceMinSeconds !== null &&
+        extendVideoMeta !== null &&
+        extendVideoMeta.duration < extendProfile.sourceMinSeconds;
 
     return (
         <div className="input-section">
@@ -205,7 +211,12 @@ export const InputSection: React.FC<InputSectionProps> = ({
                 className="generate-btn"
                 onClick={handleGenerate}
                 disabled={
-                    !currentSelectedModel || modelsLoading || isGenerating || extendPromptMissing || extendSourceBlocked
+                    !currentSelectedModel ||
+                    modelsLoading ||
+                    isGenerating ||
+                    extendPromptMissing ||
+                    extendSourceBlocked ||
+                    extendSourceTooShort
                 }
             >
                 {getGenerateButtonText()}

--- a/src/components/InputSection.tsx
+++ b/src/components/InputSection.tsx
@@ -116,12 +116,6 @@ export const InputSection: React.FC<InputSectionProps> = ({
         extendProfile !== undefined &&
         uploadedVideoFile !== null &&
         checkExtendSource(extendProfile, uploadedVideoFile, extendVideoMeta?.duration ?? null).blocked;
-    const extendSourceTooShort =
-        isExtendVideo &&
-        extendProfile !== undefined &&
-        extendProfile.sourceMinSeconds !== null &&
-        extendVideoMeta !== null &&
-        extendVideoMeta.duration < extendProfile.sourceMinSeconds;
 
     return (
         <div className="input-section">
@@ -211,12 +205,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
                 className="generate-btn"
                 onClick={handleGenerate}
                 disabled={
-                    !currentSelectedModel ||
-                    modelsLoading ||
-                    isGenerating ||
-                    extendPromptMissing ||
-                    extendSourceBlocked ||
-                    extendSourceTooShort
+                    !currentSelectedModel || modelsLoading || isGenerating || extendPromptMissing || extendSourceBlocked
                 }
             >
                 {getGenerateButtonText()}

--- a/src/hooks/useVideoGeneration.ts
+++ b/src/hooks/useVideoGeneration.ts
@@ -10,6 +10,7 @@ import {
     checkExtendSource,
     formatSourceMaxBytes,
     getExtendCapabilityProfile,
+    snapExtendDuration,
 } from '../services/extendVideoCapabilities';
 import { isSeedanceModel } from '../services/videoModels';
 import { FalQueueCancelledError, FalQueueTimeoutError, submitAndPollFalQueue } from '../services/falQueue';
@@ -116,11 +117,7 @@ export function useVideoGeneration({
                     );
                     return;
                 }
-                if (
-                    sourceDuration !== null &&
-                    extendProfile.sourceMinSeconds !== null &&
-                    sourceDuration < extendProfile.sourceMinSeconds
-                ) {
+                if (sourceCheck.tooShort && sourceDuration !== null) {
                     setStatus(
                         `Source clip is ${sourceDuration.toFixed(1)}s — under the ${extendProfile.sourceMinSeconds}s minimum for ${modelName}.`,
                         'error',
@@ -239,11 +236,10 @@ export function useVideoGeneration({
                     // takes explicit float seconds. Whole-second endpoints get integers.
                     const durationAuto = extendProfile.supportsAutoDuration && config.extendDurationAuto;
                     if (!durationAuto) {
-                        const clamped = Math.min(
-                            Math.max(config.extendDuration, extendProfile.durationMin),
-                            extendProfile.durationMax,
-                        );
-                        input.duration = extendProfile.durationStep === 1 ? Math.round(clamped) : clamped;
+                        // Snap to the profile step so the payload matches what
+                        // the panel displays (fractional carry-over from another
+                        // model must not round differently here).
+                        input.duration = snapExtendDuration(extendProfile, config.extendDuration);
                     }
 
                     if (extendProfile.supportsMode) {

--- a/src/hooks/useVideoGeneration.ts
+++ b/src/hooks/useVideoGeneration.ts
@@ -96,12 +96,12 @@ export function useVideoGeneration({
             }
 
             // Extend mode: reject sources violating the model's constraints
-            // (duration ceiling, file size, container) before paying for a
+            // (duration bounds, file size, container) before paying for a
             // storage upload. The UI disables Generate too, but revalidate
             // here in case its metadata probe lagged or failed.
             if (isExtendVideo && extendProfile && uploadedVideoFile) {
                 let sourceDuration: number | null = null;
-                if (extendProfile.sourceMaxSeconds !== null) {
+                if (extendProfile.sourceMinSeconds !== null || extendProfile.sourceMaxSeconds !== null) {
                     try {
                         sourceDuration = (await probeVideoFile(uploadedVideoFile)).duration;
                     } catch {
@@ -112,6 +112,17 @@ export function useVideoGeneration({
                 if (sourceCheck.tooLong && sourceDuration !== null) {
                     setStatus(
                         `Source clip is ${sourceDuration.toFixed(1)}s — over the ${extendProfile.sourceMaxSeconds}s limit for ${modelName}.`,
+                        'error',
+                    );
+                    return;
+                }
+                if (
+                    sourceDuration !== null &&
+                    extendProfile.sourceMinSeconds !== null &&
+                    sourceDuration < extendProfile.sourceMinSeconds
+                ) {
+                    setStatus(
+                        `Source clip is ${sourceDuration.toFixed(1)}s — under the ${extendProfile.sourceMinSeconds}s minimum for ${modelName}.`,
                         'error',
                     );
                     return;

--- a/src/services/extendVideoCapabilities.test.ts
+++ b/src/services/extendVideoCapabilities.test.ts
@@ -75,12 +75,38 @@ describe('getExtendCapabilityProfile', () => {
         });
     });
 
+    describe('Grok Imagine extend', () => {
+        it('declares the minimal schema: integer duration 2-10 and a 2-15s MP4 source', () => {
+            const profile = getExtendCapabilityProfile('xai/grok-imagine-video/extend-video');
+            expect(profile).toBeDefined();
+
+            // Integer seconds 2-10 (default 6), no auto
+            expect(profile?.durationMin).toBe(2);
+            expect(profile?.durationMax).toBe(10);
+            expect(profile?.durationStep).toBe(1);
+            expect(profile?.supportsAutoDuration).toBe(false);
+
+            // Nothing else in the input schema: end-only, no context, no
+            // resolution/aspect/audio/safety; prompt is required
+            expect(profile?.supportsMode).toBe(false);
+            expect(profile?.supportsContext).toBe(false);
+            expect(profile?.resolutions).toEqual([]);
+            expect(profile?.aspectRatios).toEqual([]);
+            expect(profile?.supportsGenerateAudio).toBe(false);
+            expect(profile?.supportsSafetyTolerance).toBe(false);
+            expect(profile?.promptRequired).toBe(true);
+
+            // Source must be an MP4 between 2 and 15 seconds
+            expect(profile?.sourceMinSeconds).toBe(2);
+            expect(profile?.sourceMaxSeconds).toBe(15);
+        });
+    });
+
     describe('unprofiled extend endpoints', () => {
         it.each([
-            // Frame-based LTX variants and later stack layers (grok, veo) are deferred.
+            // Frame-based LTX variants and the veo3.1 stack layer are deferred.
             'fal-ai/ltx-2.3-quality/extend-video',
             'fal-ai/ltx-2.3-22b/extend-video',
-            'xai/grok-imagine-video/extend-video',
             'fal-ai/veo3.1/extend-video',
             'fal-ai/veo3.1/fast/extend-video',
             'fal-ai/ltx-2.3/retake-video',

--- a/src/services/extendVideoCapabilities.test.ts
+++ b/src/services/extendVideoCapabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { checkExtendSource, getExtendCapabilityProfile } from './extendVideoCapabilities';
+import { checkExtendSource, getExtendCapabilityProfile, snapExtendDuration } from './extendVideoCapabilities';
 
 const sourceFile = (overrides: Partial<Pick<File, 'size' | 'type' | 'name'>> = {}) => ({
     size: 1_000_000,
@@ -128,6 +128,11 @@ describe('getExtendCapabilityProfile', () => {
         expect(draft?.sourceMaxBytes).toBe(50 * 1024 * 1024);
         expect(draft?.sourceMimeTypes).toEqual(['video/mp4']);
 
+        // Grok: MP4 container required, no documented size cap.
+        const grok = getExtendCapabilityProfile('xai/grok-imagine-video/extend-video');
+        expect(grok?.sourceMaxBytes).toBeNull();
+        expect(grok?.sourceMimeTypes).toEqual(['video/mp4']);
+
         // LTX 2.3 Pro: no file-level constraints documented.
         const ltx = getExtendCapabilityProfile('fal-ai/ltx-2.3/extend-video');
         expect(ltx?.sourceMaxBytes).toBeNull();
@@ -136,13 +141,14 @@ describe('getExtendCapabilityProfile', () => {
 });
 
 describe('checkExtendSource', () => {
+    const grok = getExtendCapabilityProfile('xai/grok-imagine-video/extend-video')!;
     const flux = getExtendCapabilityProfile('blackforestlabs/flux-3/extend-video')!;
-    const draft = getExtendCapabilityProfile('blackforestlabs/flux-3/extend-video/draft')!;
     const ltx = getExtendCapabilityProfile('fal-ai/ltx-2.3/extend-video')!;
 
     it('accepts an MP4 within all bounds', () => {
-        const check = checkExtendSource(flux, sourceFile(), 8);
+        const check = checkExtendSource(grok, sourceFile(), 8);
         expect(check).toEqual({
+            tooShort: false,
             tooLong: false,
             tooLarge: false,
             wrongContainer: false,
@@ -151,14 +157,13 @@ describe('checkExtendSource', () => {
         });
     });
 
-    it('flags sources over the duration ceiling', () => {
-        expect(checkExtendSource(flux, sourceFile(), 16)).toMatchObject({ tooLong: true, blocked: true });
-        // Draft has no duration ceiling.
-        expect(checkExtendSource(draft, sourceFile(), 16).tooLong).toBe(false);
+    it('flags duration bound violations', () => {
+        expect(checkExtendSource(grok, sourceFile(), 1.5)).toMatchObject({ tooShort: true, blocked: true });
+        expect(checkExtendSource(grok, sourceFile(), 16)).toMatchObject({ tooLong: true, blocked: true });
     });
 
     it('rejects non-MP4 containers when the profile requires MP4', () => {
-        const webm = checkExtendSource(flux, sourceFile({ type: 'video/webm', name: 'clip.webm' }), 8);
+        const webm = checkExtendSource(grok, sourceFile({ type: 'video/webm', name: 'clip.webm' }), 8);
         expect(webm).toMatchObject({ wrongContainer: true, blocked: true, accepted: false });
         // Unconstrained profiles accept any container.
         expect(checkExtendSource(ltx, sourceFile({ type: 'video/webm', name: 'clip.webm' }), 8).blocked).toBe(false);
@@ -166,14 +171,14 @@ describe('checkExtendSource', () => {
 
     it('accepts MP4s reported under noncanonical or empty MIME types', () => {
         // Browsers/OSes report legitimate .mp4 files as application/mp4,
-        // application/octet-stream, or "" — the extension must rescue them.
-        expect(checkExtendSource(flux, sourceFile({ type: 'application/mp4' }), 8).wrongContainer).toBe(false);
-        expect(checkExtendSource(flux, sourceFile({ type: 'application/octet-stream' }), 8).wrongContainer).toBe(false);
-        expect(checkExtendSource(flux, sourceFile({ type: '' }), 8).wrongContainer).toBe(false);
+        // application/octet-stream, or "" — aliases or the extension rescue them.
+        expect(checkExtendSource(grok, sourceFile({ type: 'application/mp4' }), 8).wrongContainer).toBe(false);
+        expect(checkExtendSource(grok, sourceFile({ type: 'application/octet-stream' }), 8).wrongContainer).toBe(false);
+        expect(checkExtendSource(grok, sourceFile({ type: '' }), 8).wrongContainer).toBe(false);
         // Neither MIME nor extension matching still fails.
-        expect(checkExtendSource(flux, sourceFile({ type: '', name: 'clip.avi' }), 8).wrongContainer).toBe(true);
+        expect(checkExtendSource(grok, sourceFile({ type: '', name: 'clip.avi' }), 8).wrongContainer).toBe(true);
         expect(
-            checkExtendSource(flux, sourceFile({ type: 'application/octet-stream', name: 'clip' }), 8).wrongContainer,
+            checkExtendSource(grok, sourceFile({ type: 'application/octet-stream', name: 'clip' }), 8).wrongContainer,
         ).toBe(true);
     });
 
@@ -183,17 +188,39 @@ describe('checkExtendSource', () => {
             blocked: true,
         });
         expect(checkExtendSource(flux, sourceFile({ size: 50_000_000 }), 8).tooLarge).toBe(false);
-        // Draft's ceiling is 50 MiB, not 50 MB.
-        expect(checkExtendSource(draft, sourceFile({ size: 50 * 1024 * 1024 + 1 }), 8).tooLarge).toBe(true);
-        expect(checkExtendSource(draft, sourceFile({ size: 50_000_001 }), 8).tooLarge).toBe(false);
+        // Grok documents no size cap.
+        expect(checkExtendSource(grok, sourceFile({ size: 500_000_000 }), 8).tooLarge).toBe(false);
     });
 
     it('treats an unknown duration as neither accepted nor blocked on duration', () => {
-        const check = checkExtendSource(flux, sourceFile(), null);
+        const check = checkExtendSource(grok, sourceFile(), null);
+        expect(check.tooShort).toBe(false);
         expect(check.tooLong).toBe(false);
         expect(check.accepted).toBe(false);
         expect(check.blocked).toBe(false);
         // File-level violations still block even with unknown duration.
-        expect(checkExtendSource(flux, sourceFile({ type: 'video/webm', name: 'c.webm' }), null).blocked).toBe(true);
+        expect(checkExtendSource(grok, sourceFile({ type: 'video/webm', name: 'c.webm' }), null).blocked).toBe(true);
+    });
+});
+
+describe('snapExtendDuration', () => {
+    const grok = getExtendCapabilityProfile('xai/grok-imagine-video/extend-video')!;
+    const ltx = getExtendCapabilityProfile('fal-ai/ltx-2.3/extend-video')!;
+
+    it('snaps fractional carry-over to whole seconds on integer-step profiles', () => {
+        // An LTX half-second value must not display 2.5 while Grok is sent 3.
+        expect(snapExtendDuration(grok, 2.5)).toBe(3);
+        expect(snapExtendDuration(grok, 9.4)).toBe(9);
+    });
+
+    it('preserves half-second values on 0.5-step profiles', () => {
+        expect(snapExtendDuration(ltx, 2.5)).toBe(2.5);
+        expect(snapExtendDuration(ltx, 2.3)).toBe(2.5);
+    });
+
+    it('clamps into the profile bounds', () => {
+        expect(snapExtendDuration(grok, 25)).toBe(10);
+        expect(snapExtendDuration(grok, 0.4)).toBe(2);
+        expect(snapExtendDuration(ltx, 25)).toBe(20);
     });
 });

--- a/src/services/extendVideoCapabilities.ts
+++ b/src/services/extendVideoCapabilities.ts
@@ -40,6 +40,8 @@ export interface ExtendCapabilityProfile {
     supportsSafetyTolerance: boolean;
     /** Whether `prompt` is required (FLUX) or optional (LTX 2.3 Pro). */
     promptRequired: boolean;
+    /** Minimum source clip length in seconds, or null when unconstrained (Grok: 2s). */
+    sourceMinSeconds: number | null;
     /** Maximum source clip length in seconds, or null when unconstrained. */
     sourceMaxSeconds: number | null;
     /** Maximum source file size in bytes, or null when the docs state none. */
@@ -50,6 +52,8 @@ export interface ExtendCapabilityProfile {
      * client-side — the API stays the final validator there.
      */
     sourceMimeTypes: string[];
+    /** Extra source constraint shown on the accepted chip (e.g. "MP4 · ≤ 50 MiB"). */
+    sourceNote?: string;
     /** Draft tier: 720p-only preview that also returns a reusable draft_cache. */
     isDraft: boolean;
 }
@@ -75,6 +79,7 @@ function flux3ExtendProfile(overrides: Partial<ExtendCapabilityProfile>): Extend
         supportsGenerateAudio: true,
         supportsSafetyTolerance: true,
         promptRequired: true,
+        sourceMinSeconds: null,
         sourceMaxSeconds: 15,
         sourceMaxBytes: 50_000_000,
         sourceMimeTypes: ['video/mp4'],
@@ -98,24 +103,48 @@ const PROFILES: Record<string, ExtendCapabilityProfile> = {
         supportsGenerateAudio: false,
         supportsSafetyTolerance: false,
         promptRequired: false,
+        sourceMinSeconds: null,
         sourceMaxSeconds: null,
         sourceMaxBytes: null,
         sourceMimeTypes: [],
         isDraft: false,
     },
     // Source clip: MP4, under 50 MB and under 15 seconds.
-    'blackforestlabs/flux-3/extend-video': flux3ExtendProfile({}),
+    'blackforestlabs/flux-3/extend-video': flux3ExtendProfile({ sourceNote: 'MP4 · ≤ 50 MB' }),
     // Draft: no resolution input; source limit is 50 MiB with no stated
     // duration cap; returns draft_cache alongside the video.
     'blackforestlabs/flux-3/extend-video/draft': flux3ExtendProfile({
         resolutions: [],
         sourceMaxSeconds: null,
         sourceMaxBytes: 50 * 1024 * 1024,
+        sourceNote: 'MP4 · ≤ 50 MiB',
         isDraft: true,
     }),
+    // Grok Imagine: the minimal extend schema — required prompt, source clip,
+    // integer duration 2-10 (default 6). Source must be MP4 (H.264/H.265/AV1)
+    // and 2-15 seconds; the extension is always appended at the end.
+    'xai/grok-imagine-video/extend-video': {
+        durationMin: 2,
+        durationMax: 10,
+        durationStep: 1,
+        supportsAutoDuration: false,
+        supportsMode: false,
+        supportsContext: false,
+        resolutions: [],
+        aspectRatios: [],
+        supportsGenerateAudio: false,
+        supportsSafetyTolerance: false,
+        promptRequired: true,
+        sourceMinSeconds: 2,
+        sourceMaxSeconds: 15,
+        sourceMaxBytes: null,
+        sourceMimeTypes: ['video/mp4'],
+        sourceNote: 'MP4 (H.264/H.265/AV1)',
+        isDraft: false,
+    },
     // fal-ai/ltx-2.3-quality and ltx-2.3-22b extend are frame-based APIs
     // (num_frames/num_context_frames, 19B-style knobs) — deferred.
-    // xai/grok-imagine-video and fal-ai/veo3.1 extend land in later stack layers.
+    // fal-ai/veo3.1 extend lands in the next stack layer.
 };
 
 /**

--- a/src/services/extendVideoCapabilities.ts
+++ b/src/services/extendVideoCapabilities.ts
@@ -48,8 +48,9 @@ export interface ExtendCapabilityProfile {
     sourceMaxBytes: number | null;
     /**
      * Accepted source container MIME types (e.g. ['video/mp4']); empty =
-     * unconstrained. Codec requirements inside a container can't be checked
-     * client-side — the API stays the final validator there.
+     * unconstrained. Codec requirements inside a container (Grok's
+     * H.264/H.265/AV1) can't be checked client-side — `sourceNote` carries
+     * them for display only.
      */
     sourceMimeTypes: string[];
     /** Extra source constraint shown on the accepted chip (e.g. "MP4 · ≤ 50 MiB"). */
@@ -176,6 +177,7 @@ function matchesContainer(file: Pick<File, 'type' | 'name'>, required: string[])
 }
 
 export interface ExtendSourceCheck {
+    tooShort: boolean;
     tooLong: boolean;
     tooLarge: boolean;
     wrongContainer: boolean;
@@ -190,7 +192,7 @@ export interface ExtendSourceCheck {
 
 /**
  * Validate a source clip against everything the profile can check
- * client-side: duration ceiling (when known), file size, and container.
+ * client-side: duration bounds (when known), file size, and container.
  * Codecs are not inspected — the API remains the final validator there.
  * Shared by the chips, the Generate gating, and the hook's pre-upload check
  * so the three never disagree.
@@ -200,12 +202,15 @@ export function checkExtendSource(
     file: Pick<File, 'size' | 'type' | 'name'>,
     durationSeconds: number | null,
 ): ExtendSourceCheck {
+    const tooShort =
+        profile.sourceMinSeconds !== null && durationSeconds !== null && durationSeconds < profile.sourceMinSeconds;
     const tooLong =
         profile.sourceMaxSeconds !== null && durationSeconds !== null && durationSeconds > profile.sourceMaxSeconds;
     const tooLarge = profile.sourceMaxBytes !== null && file.size > profile.sourceMaxBytes;
     const wrongContainer = profile.sourceMimeTypes.length > 0 && !matchesContainer(file, profile.sourceMimeTypes);
-    const blocked = tooLong || tooLarge || wrongContainer;
+    const blocked = tooShort || tooLong || tooLarge || wrongContainer;
     return {
+        tooShort,
         tooLong,
         tooLarge,
         wrongContainer,
@@ -217,4 +222,16 @@ export function checkExtendSource(
 /** Human label for a source size limit, honoring the unit the docs use. */
 export function formatSourceMaxBytes(bytes: number): string {
     return bytes % (1024 * 1024) === 0 ? `${bytes / (1024 * 1024)} MiB` : `${bytes / 1_000_000} MB`;
+}
+
+/**
+ * Clamp a persisted extension length into the profile's bounds and snap it
+ * to the slider step, so a fractional value carried over from another model
+ * (LTX allows 2.5s) can't display one number while a whole-second endpoint
+ * is sent another.
+ */
+export function snapExtendDuration(profile: ExtendCapabilityProfile, seconds: number): number {
+    const clamped = Math.min(Math.max(seconds, profile.durationMin), profile.durationMax);
+    const snapped = Math.round(clamped / profile.durationStep) * profile.durationStep;
+    return Math.min(Math.max(snapped, profile.durationMin), profile.durationMax);
 }

--- a/src/services/videoModels.ts
+++ b/src/services/videoModels.ts
@@ -474,6 +474,14 @@ export const CURATED_EXTEND_VIDEO_MODELS: ModelConfig[] = [
         supportsImageInput: false,
         outputType: 'video',
     },
+    {
+        endpointId: 'xai/grok-imagine-video/extend-video',
+        displayName: 'Grok Imagine Extend',
+        category: 'extend-video',
+        description: 'Continue an MP4 clip (2-15s source) by 2-10 seconds',
+        supportsImageInput: false,
+        outputType: 'video',
+    },
 ];
 
 /** All curated video models */


### PR DESCRIPTION
Profile xai/grok-imagine-video/extend-video — the minimal extend schema:
required prompt, source clip, integer duration 2-10s (default 6). The
source must be MP4 (H.264/H.265/AV1) between 2 and 15 seconds, so the
profile grows two source-constraint fields the earlier endpoints didn't
need: sourceMinSeconds (warning chip when the clip is too short) and
sourceNote (shown on the accepted chip; also added to FLUX standard/draft
for their MP4/50MB limits). No payload changes — the profile-driven
branch already sends exactly prompt + video_url + duration for it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>