### PR TITLE
feat(video): add Veo 3.1 extend (fast + standard) via capability profiles

### DIFF
--- a/src/components/ExtendTimeline.tsx
+++ b/src/components/ExtendTimeline.tsx
@@ -121,7 +121,7 @@ export const ExtendTimeline: React.FC<ExtendTimelineProps> = ({
                         max={maxSec}
                         step={stepSec}
                         value={extSec}
-                        disabled={durationAuto}
+                        disabled={durationAuto || minSec === maxSec}
                         onChange={(e) => onExtChange(parseFloat(e.target.value))}
                         aria-label="Extension length in seconds"
                     />

--- a/src/components/ExtendVideoOptions.tsx
+++ b/src/components/ExtendVideoOptions.tsx
@@ -72,9 +72,9 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
 
     // Guard against degenerate metadata (e.g. streams with unknown duration).
     const srcDuration = meta && Number.isFinite(meta.duration) && meta.duration > 0 ? meta.duration : null;
-    // One predicate for duration, size, and container — the same check gates
-    // Generate in InputSection, so chips and button state always agree.
-    const srcCheck = checkExtendSource(profile, videoFile, srcDuration);
+    // One predicate for duration, dimensions, size, and container — the same
+    // check gates Generate in InputSection, so chips and button state agree.
+    const srcCheck = checkExtendSource(profile, videoFile, srcDuration !== null && meta !== null ? meta : null);
     const totalSec = srcDuration !== null ? srcDuration + effectiveExt : null;
     const resultOverCeiling =
         profile.sourceMaxSeconds !== null && totalSec !== null && totalSec > profile.sourceMaxSeconds;
@@ -152,6 +152,15 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
                     )}
                     {srcCheck.wrongContainer && (
                         <span className="extend-chip warning">&#9888; Source must be an MP4 file for this model</span>
+                    )}
+                    {srcCheck.wrongDimensions && meta && (
+                        <span className="extend-chip warning">
+                            &#9888; Source is {meta.width}&times;{meta.height} &mdash; this model needs{' '}
+                            {profile.sourceNote ?? 'a supported resolution'}
+                        </span>
+                    )}
+                    {profile.sourceRequirementNote && (
+                        <span className="extend-chip">{profile.sourceRequirementNote}</span>
                     )}
                     {profile.isDraft && <span className="extend-chip draft">Draft preview &middot; 720p only</span>}
                 </div>

--- a/src/components/ExtendVideoOptions.tsx
+++ b/src/components/ExtendVideoOptions.tsx
@@ -63,6 +63,8 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
     }
 
     const durationAuto = profile.supportsAutoDuration && config.extendDurationAuto;
+    // A single-value duration range (Veo's fixed 7s pass) has nothing to choose.
+    const durationFixed = profile.durationMin === profile.durationMax;
     const contextAuto = !profile.supportsContext || config.extendContextAuto;
     const mode = profile.supportsMode && config.extendMode === 'start' ? 'start' : 'end';
     const extSec = snapExtendDuration(profile, config.extendDuration);
@@ -204,7 +206,9 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
                     <div className="extend-control-row">
                         <label htmlFor="extend-duration">
                             Extension Duration:{' '}
-                            <span className="extend-value">{durationAuto ? 'auto' : fmt(extSec)}</span>
+                            <span className="extend-value">
+                                {durationAuto ? 'auto' : fmt(durationFixed ? profile.durationMax : extSec)}
+                            </span>
                         </label>
                         {profile.supportsAutoDuration && (
                             <div className="extend-toggle">
@@ -225,23 +229,27 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
                             </div>
                         )}
                     </div>
-                    <input
-                        id="extend-duration"
-                        type="range"
-                        min={profile.durationMin}
-                        max={profile.durationMax}
-                        step={profile.durationStep}
-                        value={extSec}
-                        disabled={durationAuto}
-                        onChange={(e) => config.setExtendDuration(parseFloat(e.target.value))}
-                        className="extend-range"
-                    />
+                    {!durationFixed && (
+                        <input
+                            id="extend-duration"
+                            type="range"
+                            min={profile.durationMin}
+                            max={profile.durationMax}
+                            step={profile.durationStep}
+                            value={extSec}
+                            disabled={durationAuto}
+                            onChange={(e) => config.setExtendDuration(parseFloat(e.target.value))}
+                            className="extend-range"
+                        />
+                    )}
                     <span className="hint">
-                        {durationAuto
-                            ? `(auto — the model picks the length, ${profile.durationMin}–${profile.durationMax}s)`
-                            : `(${profile.durationMin}–${profile.durationMax}s per pass, ${
-                                  profile.durationStep === 1 ? 'whole seconds' : `${profile.durationStep}s steps`
-                              })`}
+                        {durationFixed
+                            ? `(fixed ${profile.durationMax}s per pass)`
+                            : durationAuto
+                              ? `(auto — the model picks the length, ${profile.durationMin}–${profile.durationMax}s)`
+                              : `(${profile.durationMin}–${profile.durationMax}s per pass, ${
+                                    profile.durationStep === 1 ? 'whole seconds' : `${profile.durationStep}s steps`
+                                })`}
                     </span>
                 </div>
 
@@ -332,21 +340,67 @@ export const ExtendVideoOptions: React.FC<ExtendVideoOptionsProps> = ({ selected
                     </div>
                 )}
 
-                {profile.supportsSafetyTolerance && (
+                {profile.safetyToleranceValues.length > 0 && (
                     <div className="form-group">
                         <label htmlFor="extend-safety-tolerance">Safety Tolerance:</label>
                         <select
                             id="extend-safety-tolerance"
-                            value={config.extendSafetyTolerance}
+                            value={Math.min(
+                                Math.max(config.extendSafetyTolerance, profile.safetyToleranceValues[0]),
+                                profile.safetyToleranceValues[profile.safetyToleranceValues.length - 1],
+                            )}
                             onChange={(e) => config.setExtendSafetyTolerance(parseInt(e.target.value, 10))}
                         >
-                            {[0, 1, 2, 3, 4].map((level) => (
+                            {profile.safetyToleranceValues.map((level) => (
                                 <option key={level} value={level}>
                                     {level}
                                 </option>
                             ))}
                         </select>
-                        <span className="hint"> (0 = strictest, 4 = most permissive)</span>
+                        <span className="hint">
+                            {' '}
+                            ({profile.safetyToleranceValues[0]} = strictest,{' '}
+                            {profile.safetyToleranceValues[profile.safetyToleranceValues.length - 1]} = most permissive)
+                        </span>
+                    </div>
+                )}
+
+                {profile.supportsNegativePrompt && (
+                    <div className="form-group">
+                        <label htmlFor="extend-negative-prompt">Negative Prompt:</label>
+                        <textarea
+                            id="extend-negative-prompt"
+                            value={config.videoNegativePrompt}
+                            onChange={(e) => config.setVideoNegativePrompt(e.target.value)}
+                            placeholder="Content to avoid (e.g., blur, distort, low quality)"
+                            rows={2}
+                            className="negative-prompt-textarea"
+                        />
+                    </div>
+                )}
+
+                {profile.supportsSeed && (
+                    <div className="form-group">
+                        <label htmlFor="extend-seed">Seed (leave blank for random):</label>
+                        <input
+                            id="extend-seed"
+                            type="number"
+                            value={config.videoSeed !== null ? config.videoSeed : ''}
+                            onChange={(e) => config.setVideoSeed(e.target.value ? parseInt(e.target.value, 10) : null)}
+                        />
+                    </div>
+                )}
+
+                {profile.supportsAutoFix && (
+                    <div className="form-group">
+                        <label htmlFor="extend-auto-fix">Auto-Fix Prompt:</label>
+                        <input
+                            id="extend-auto-fix"
+                            type="checkbox"
+                            checked={config.extendAutoFix}
+                            onChange={(e) => config.setExtendAutoFix(e.target.checked)}
+                        />
+                        <span className="hint"> (rewrite prompts that fail content-policy checks)</span>
                     </div>
                 )}
             </div>

--- a/src/components/InputSection.tsx
+++ b/src/components/InputSection.tsx
@@ -115,7 +115,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
         isExtendVideo &&
         extendProfile !== undefined &&
         uploadedVideoFile !== null &&
-        checkExtendSource(extendProfile, uploadedVideoFile, extendVideoMeta?.duration ?? null).blocked;
+        checkExtendSource(extendProfile, uploadedVideoFile, extendVideoMeta).blocked;
 
     return (
         <div className="input-section">

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -54,8 +54,9 @@ export interface ConfigState {
     extendMode: string; // 'end' | 'start' (LTX only)
     extendContext: number; // LTX only: seconds of source context (1-20)
     extendContextAuto: boolean; // LTX only: omit `context` to maximize it
-    extendAspectRatio: string; // FLUX only: 'auto', '21:9', '2:1', ...
-    extendSafetyTolerance: number; // FLUX only: 0 (strict) - 4 (permissive)
+    extendAspectRatio: string; // FLUX/Veo: 'auto', '21:9', '2:1', ...
+    extendSafetyTolerance: number; // FLUX 0-4 / Veo 1-6 (clamped per profile)
+    extendAutoFix: boolean; // Veo only: rewrite prompts that fail content policy
     // Audio generation settings
     audioOutputFormat: string; // 'mp3' | 'wav' | 'flac' | 'pcm'
     audioSeed: number | null; // Seed for reproducibility
@@ -161,6 +162,7 @@ interface ConfigContextType extends ConfigState {
     setExtendContextAuto: (value: boolean) => void;
     setExtendAspectRatio: (value: string) => void;
     setExtendSafetyTolerance: (value: number) => void;
+    setExtendAutoFix: (value: boolean) => void;
     // Audio generation setters
     setAudioOutputFormat: (value: string) => void;
     setAudioSeed: (value: number | null) => void;
@@ -334,6 +336,7 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
     const [extendSafetyTolerance, setExtendSafetyTolerance] = useState<number>(
         parseInt(localStorage.getItem('EXTEND_SAFETY_TOLERANCE') || '2', 10),
     );
+    const [extendAutoFix, setExtendAutoFix] = useState<boolean>(localStorage.getItem('EXTEND_AUTO_FIX') === 'true');
     // Audio generation settings
     const [audioOutputFormat, setAudioOutputFormat] = useState<string>(
         localStorage.getItem('AUDIO_OUTPUT_FORMAT') || 'mp3',
@@ -490,6 +493,7 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
         localStorage.setItem('EXTEND_CONTEXT_AUTO', extendContextAuto.toString());
         localStorage.setItem('EXTEND_ASPECT_RATIO', extendAspectRatio);
         localStorage.setItem('EXTEND_SAFETY_TOLERANCE', extendSafetyTolerance.toString());
+        localStorage.setItem('EXTEND_AUTO_FIX', extendAutoFix.toString());
         // Audio generation persistence
         localStorage.setItem('AUDIO_OUTPUT_FORMAT', audioOutputFormat);
         localStorage.setItem('AUDIO_SEED', audioSeed !== null ? audioSeed.toString() : 'null');
@@ -585,6 +589,7 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
         extendContextAuto,
         extendAspectRatio,
         extendSafetyTolerance,
+        extendAutoFix,
         audioOutputFormat,
         audioSeed,
         ttsVoiceId,
@@ -720,6 +725,8 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
                 setExtendAspectRatio,
                 extendSafetyTolerance,
                 setExtendSafetyTolerance,
+                extendAutoFix,
+                setExtendAutoFix,
                 // Audio generation
                 audioOutputFormat,
                 setAudioOutputFormat,

--- a/src/hooks/useVideoGeneration.ts
+++ b/src/hooks/useVideoGeneration.ts
@@ -11,6 +11,7 @@ import {
     formatSourceMaxBytes,
     getExtendCapabilityProfile,
     snapExtendDuration,
+    type ExtendSourceMetadata,
 } from '../services/extendVideoCapabilities';
 import { isSeedanceModel } from '../services/videoModels';
 import { FalQueueCancelledError, FalQueueTimeoutError, submitAndPollFalQueue } from '../services/falQueue';
@@ -97,29 +98,40 @@ export function useVideoGeneration({
             }
 
             // Extend mode: reject sources violating the model's constraints
-            // (duration bounds, file size, container) before paying for a
-            // storage upload. The UI disables Generate too, but revalidate
-            // here in case its metadata probe lagged or failed.
+            // (duration bounds, dimensions, file size, container) before
+            // paying for a storage upload. The UI disables Generate too, but
+            // revalidate here in case its metadata probe lagged or failed.
             if (isExtendVideo && extendProfile && uploadedVideoFile) {
-                let sourceDuration: number | null = null;
-                if (extendProfile.sourceMinSeconds !== null || extendProfile.sourceMaxSeconds !== null) {
+                let sourceMeta: ExtendSourceMetadata | null = null;
+                const needsProbe =
+                    extendProfile.sourceMinSeconds !== null ||
+                    extendProfile.sourceMaxSeconds !== null ||
+                    extendProfile.sourceDimensions.length > 0;
+                if (needsProbe) {
                     try {
-                        sourceDuration = (await probeVideoFile(uploadedVideoFile)).duration;
+                        sourceMeta = await probeVideoFile(uploadedVideoFile);
                     } catch {
                         // Unreadable metadata locally — let the API validate the upload.
                     }
                 }
-                const sourceCheck = checkExtendSource(extendProfile, uploadedVideoFile, sourceDuration);
-                if (sourceCheck.tooLong && sourceDuration !== null) {
+                const sourceCheck = checkExtendSource(extendProfile, uploadedVideoFile, sourceMeta);
+                if (sourceCheck.tooLong && sourceMeta !== null) {
                     setStatus(
-                        `Source clip is ${sourceDuration.toFixed(1)}s — over the ${extendProfile.sourceMaxSeconds}s limit for ${modelName}.`,
+                        `Source clip is ${sourceMeta.duration.toFixed(1)}s — over the ${extendProfile.sourceMaxSeconds}s limit for ${modelName}.`,
                         'error',
                     );
                     return;
                 }
-                if (sourceCheck.tooShort && sourceDuration !== null) {
+                if (sourceCheck.tooShort && sourceMeta !== null) {
                     setStatus(
-                        `Source clip is ${sourceDuration.toFixed(1)}s — under the ${extendProfile.sourceMinSeconds}s minimum for ${modelName}.`,
+                        `Source clip is ${sourceMeta.duration.toFixed(1)}s — under the ${extendProfile.sourceMinSeconds}s minimum for ${modelName}.`,
+                        'error',
+                    );
+                    return;
+                }
+                if (sourceCheck.wrongDimensions && sourceMeta !== null) {
+                    setStatus(
+                        `Source is ${sourceMeta.width}×${sourceMeta.height} — ${modelName} needs ${extendProfile.sourceNote ?? 'a supported resolution'}.`,
                         'error',
                     );
                     return;

--- a/src/hooks/useVideoGeneration.ts
+++ b/src/hooks/useVideoGeneration.ts
@@ -232,10 +232,13 @@ export function useVideoGeneration({
                 }
 
                 if (extendProfile) {
-                    // Duration: FLUX defaults to "auto" (omit the field); LTX always
-                    // takes explicit float seconds. Whole-second endpoints get integers.
+                    // Duration: FLUX defaults to "auto" and Veo has a single fixed
+                    // length (min === max) — omit the field in both cases so the
+                    // server default applies. LTX always takes explicit float
+                    // seconds; whole-second endpoints get integers.
                     const durationAuto = extendProfile.supportsAutoDuration && config.extendDurationAuto;
-                    if (!durationAuto) {
+                    const durationFixed = extendProfile.durationMin === extendProfile.durationMax;
+                    if (!durationAuto && !durationFixed) {
                         // Snap to the profile step so the payload matches what
                         // the panel displays (fractional carry-over from another
                         // model must not round differently here).
@@ -267,8 +270,29 @@ export function useVideoGeneration({
                         input.generate_audio = config.generateAudio;
                     }
 
-                    if (extendProfile.supportsSafetyTolerance) {
-                        input.safety_tolerance = Math.min(Math.max(config.extendSafetyTolerance, 0), 4);
+                    // Safety tolerance: clamp the stored level into the endpoint's
+                    // range; FLUX takes an integer, Veo the digit as a string.
+                    if (extendProfile.safetyToleranceValues.length > 0) {
+                        const values = extendProfile.safetyToleranceValues;
+                        const clamped = Math.min(
+                            Math.max(config.extendSafetyTolerance, values[0]),
+                            values[values.length - 1],
+                        );
+                        input.safety_tolerance =
+                            extendProfile.safetyToleranceFormat === 'string' ? String(clamped) : clamped;
+                    }
+
+                    if (extendProfile.supportsNegativePrompt && config.videoNegativePrompt) {
+                        input.negative_prompt = config.videoNegativePrompt;
+                    }
+
+                    if (extendProfile.supportsSeed && config.videoSeed !== null) {
+                        input.seed = config.videoSeed;
+                    }
+
+                    // auto_fix defaults to false server-side; only send when enabled.
+                    if (extendProfile.supportsAutoFix && config.extendAutoFix) {
+                        input.auto_fix = true;
                     }
                 }
             } else if (profile) {

--- a/src/services/extendVideoCapabilities.test.ts
+++ b/src/services/extendVideoCapabilities.test.ts
@@ -27,7 +27,7 @@ describe('getExtendCapabilityProfile', () => {
             expect(profile?.resolutions).toEqual([]);
             expect(profile?.aspectRatios).toEqual([]);
             expect(profile?.supportsGenerateAudio).toBe(false);
-            expect(profile?.supportsSafetyTolerance).toBe(false);
+            expect(profile?.safetyToleranceValues).toEqual([]);
             expect(profile?.promptRequired).toBe(false);
 
             expect(profile?.sourceMaxSeconds).toBeNull();
@@ -52,10 +52,14 @@ describe('getExtendCapabilityProfile', () => {
                 expect(profile?.supportsMode).toBe(false);
                 expect(profile?.supportsContext).toBe(false);
 
-                // Aspect enum includes 2:1 (and not 9:21); audio and safety tolerance exist
+                // Aspect enum includes 2:1 (and not 9:21); audio and integer
+                // safety tolerance 0-4 exist; no negative_prompt/seed/auto_fix
                 expect(profile?.aspectRatios).toEqual(['auto', '21:9', '2:1', '16:9', '4:3', '1:1', '3:4', '9:16']);
                 expect(profile?.supportsGenerateAudio).toBe(true);
-                expect(profile?.supportsSafetyTolerance).toBe(true);
+                expect(profile?.safetyToleranceValues).toEqual([0, 1, 2, 3, 4]);
+                expect(profile?.safetyToleranceFormat).toBe('integer');
+                expect(profile?.supportsNegativePrompt).toBe(false);
+                expect(profile?.supportsSeed).toBe(false);
                 expect(profile?.promptRequired).toBe(true);
             },
         );
@@ -93,7 +97,7 @@ describe('getExtendCapabilityProfile', () => {
             expect(profile?.resolutions).toEqual([]);
             expect(profile?.aspectRatios).toEqual([]);
             expect(profile?.supportsGenerateAudio).toBe(false);
-            expect(profile?.supportsSafetyTolerance).toBe(false);
+            expect(profile?.safetyToleranceValues).toEqual([]);
             expect(profile?.promptRequired).toBe(true);
 
             // Source must be an MP4 between 2 and 15 seconds
@@ -102,13 +106,47 @@ describe('getExtendCapabilityProfile', () => {
         });
     });
 
+    describe('Veo 3.1 extend', () => {
+        it.each(['fal-ai/veo3.1/extend-video', 'fal-ai/veo3.1/fast/extend-video'])(
+            '%s declares the shared Veo schema (fast and standard differ only in price)',
+            (endpointId) => {
+                const profile = getExtendCapabilityProfile(endpointId);
+                expect(profile).toBeDefined();
+
+                // Fixed 7s per pass: min === max means the duration field is
+                // omitted and the server default ("7s") applies.
+                expect(profile?.durationMin).toBe(7);
+                expect(profile?.durationMax).toBe(7);
+                expect(profile?.supportsAutoDuration).toBe(false);
+
+                // End-only, no context; resolution and 3-value aspect enum exist
+                expect(profile?.supportsMode).toBe(false);
+                expect(profile?.supportsContext).toBe(false);
+                expect(profile?.resolutions).toEqual(['720p', '1080p']);
+                expect(profile?.aspectRatios).toEqual(['auto', '16:9', '9:16']);
+
+                // Audio, string safety tolerance "1"-"6", negative prompt,
+                // seed, and auto_fix; prompt required
+                expect(profile?.supportsGenerateAudio).toBe(true);
+                expect(profile?.safetyToleranceValues).toEqual([1, 2, 3, 4, 5, 6]);
+                expect(profile?.safetyToleranceFormat).toBe('string');
+                expect(profile?.supportsNegativePrompt).toBe(true);
+                expect(profile?.supportsSeed).toBe(true);
+                expect(profile?.supportsAutoFix).toBe(true);
+                expect(profile?.promptRequired).toBe(true);
+
+                // Source constraint is provenance/format, not a duration cap
+                expect(profile?.sourceMaxSeconds).toBeNull();
+                expect(profile?.sourceNote).toContain('Veo-created');
+            },
+        );
+    });
+
     describe('unprofiled extend endpoints', () => {
         it.each([
-            // Frame-based LTX variants and the veo3.1 stack layer are deferred.
+            // Frame-based LTX variants are deferred.
             'fal-ai/ltx-2.3-quality/extend-video',
             'fal-ai/ltx-2.3-22b/extend-video',
-            'fal-ai/veo3.1/extend-video',
-            'fal-ai/veo3.1/fast/extend-video',
             'fal-ai/ltx-2.3/retake-video',
         ])('%s has no profile yet', (endpointId) => {
             expect(getExtendCapabilityProfile(endpointId)).toBeUndefined();

--- a/src/services/extendVideoCapabilities.test.ts
+++ b/src/services/extendVideoCapabilities.test.ts
@@ -8,6 +8,8 @@ const sourceFile = (overrides: Partial<Pick<File, 'size' | 'type' | 'name'>> = {
     ...overrides,
 });
 
+const srcMeta = (duration: number, width = 1280, height = 720) => ({ duration, width, height });
+
 describe('getExtendCapabilityProfile', () => {
     describe('LTX 2.3 Pro extend', () => {
         it('declares float duration 2-20 with mode and context, nothing else', () => {
@@ -135,9 +137,18 @@ describe('getExtendCapabilityProfile', () => {
                 expect(profile?.supportsAutoFix).toBe(true);
                 expect(profile?.promptRequired).toBe(true);
 
-                // Source constraint is provenance/format, not a duration cap
+                // No duration cap; the checkable constraint is the exact Veo
+                // output sizes, while provenance (Veo-created) is unverifiable
+                // and surfaced as a requirement note instead of an acceptance.
                 expect(profile?.sourceMaxSeconds).toBeNull();
-                expect(profile?.sourceNote).toContain('Veo-created');
+                expect(profile?.sourceDimensions).toEqual([
+                    { width: 1280, height: 720 },
+                    { width: 1920, height: 1080 },
+                    { width: 720, height: 1280 },
+                    { width: 1080, height: 1920 },
+                ]);
+                expect(profile?.sourceNote).toBe('720p/1080p · 16:9 or 9:16');
+                expect(profile?.sourceRequirementNote).toContain('Veo-created');
             },
         );
     });
@@ -182,61 +193,89 @@ describe('checkExtendSource', () => {
     const grok = getExtendCapabilityProfile('xai/grok-imagine-video/extend-video')!;
     const flux = getExtendCapabilityProfile('blackforestlabs/flux-3/extend-video')!;
     const ltx = getExtendCapabilityProfile('fal-ai/ltx-2.3/extend-video')!;
+    const veo = getExtendCapabilityProfile('fal-ai/veo3.1/extend-video')!;
 
     it('accepts an MP4 within all bounds', () => {
-        const check = checkExtendSource(grok, sourceFile(), 8);
+        const check = checkExtendSource(grok, sourceFile(), srcMeta(8));
         expect(check).toEqual({
             tooShort: false,
             tooLong: false,
             tooLarge: false,
             wrongContainer: false,
+            wrongDimensions: false,
             blocked: false,
             accepted: true,
         });
     });
 
     it('flags duration bound violations', () => {
-        expect(checkExtendSource(grok, sourceFile(), 1.5)).toMatchObject({ tooShort: true, blocked: true });
-        expect(checkExtendSource(grok, sourceFile(), 16)).toMatchObject({ tooLong: true, blocked: true });
+        expect(checkExtendSource(grok, sourceFile(), srcMeta(1.5))).toMatchObject({ tooShort: true, blocked: true });
+        expect(checkExtendSource(grok, sourceFile(), srcMeta(16))).toMatchObject({ tooLong: true, blocked: true });
     });
 
     it('rejects non-MP4 containers when the profile requires MP4', () => {
-        const webm = checkExtendSource(grok, sourceFile({ type: 'video/webm', name: 'clip.webm' }), 8);
+        const webm = checkExtendSource(grok, sourceFile({ type: 'video/webm', name: 'clip.webm' }), srcMeta(8));
         expect(webm).toMatchObject({ wrongContainer: true, blocked: true, accepted: false });
         // Unconstrained profiles accept any container.
-        expect(checkExtendSource(ltx, sourceFile({ type: 'video/webm', name: 'clip.webm' }), 8).blocked).toBe(false);
+        expect(checkExtendSource(ltx, sourceFile({ type: 'video/webm', name: 'clip.webm' }), srcMeta(8)).blocked).toBe(
+            false,
+        );
     });
 
     it('accepts MP4s reported under noncanonical or empty MIME types', () => {
         // Browsers/OSes report legitimate .mp4 files as application/mp4,
         // application/octet-stream, or "" — aliases or the extension rescue them.
-        expect(checkExtendSource(grok, sourceFile({ type: 'application/mp4' }), 8).wrongContainer).toBe(false);
-        expect(checkExtendSource(grok, sourceFile({ type: 'application/octet-stream' }), 8).wrongContainer).toBe(false);
-        expect(checkExtendSource(grok, sourceFile({ type: '' }), 8).wrongContainer).toBe(false);
-        // Neither MIME nor extension matching still fails.
-        expect(checkExtendSource(grok, sourceFile({ type: '', name: 'clip.avi' }), 8).wrongContainer).toBe(true);
+        expect(checkExtendSource(grok, sourceFile({ type: 'application/mp4' }), srcMeta(8)).wrongContainer).toBe(false);
         expect(
-            checkExtendSource(grok, sourceFile({ type: 'application/octet-stream', name: 'clip' }), 8).wrongContainer,
+            checkExtendSource(grok, sourceFile({ type: 'application/octet-stream' }), srcMeta(8)).wrongContainer,
+        ).toBe(false);
+        expect(checkExtendSource(grok, sourceFile({ type: '' }), srcMeta(8)).wrongContainer).toBe(false);
+        // Neither MIME nor extension matching still fails.
+        expect(checkExtendSource(grok, sourceFile({ type: '', name: 'clip.avi' }), srcMeta(8)).wrongContainer).toBe(
+            true,
+        );
+        expect(
+            checkExtendSource(grok, sourceFile({ type: 'application/octet-stream', name: 'clip' }), srcMeta(8))
+                .wrongContainer,
         ).toBe(true);
     });
 
     it('flags files over the size limit', () => {
-        expect(checkExtendSource(flux, sourceFile({ size: 50_000_001 }), 8)).toMatchObject({
+        expect(checkExtendSource(flux, sourceFile({ size: 50_000_001 }), srcMeta(8))).toMatchObject({
             tooLarge: true,
             blocked: true,
         });
-        expect(checkExtendSource(flux, sourceFile({ size: 50_000_000 }), 8).tooLarge).toBe(false);
+        expect(checkExtendSource(flux, sourceFile({ size: 50_000_000 }), srcMeta(8)).tooLarge).toBe(false);
         // Grok documents no size cap.
-        expect(checkExtendSource(grok, sourceFile({ size: 500_000_000 }), 8).tooLarge).toBe(false);
+        expect(checkExtendSource(grok, sourceFile({ size: 500_000_000 }), srcMeta(8)).tooLarge).toBe(false);
     });
 
-    it('treats an unknown duration as neither accepted nor blocked on duration', () => {
+    it('checks Veo sources against its exact output sizes', () => {
+        // All four Veo output sizes pass; anything else is blocked.
+        expect(checkExtendSource(veo, sourceFile(), srcMeta(8, 1280, 720)).accepted).toBe(true);
+        expect(checkExtendSource(veo, sourceFile(), srcMeta(8, 1080, 1920)).accepted).toBe(true);
+        expect(checkExtendSource(veo, sourceFile(), srcMeta(8, 854, 480))).toMatchObject({
+            wrongDimensions: true,
+            blocked: true,
+            accepted: false,
+        });
+        expect(checkExtendSource(veo, sourceFile(), srcMeta(8, 1024, 1024)).wrongDimensions).toBe(true);
+        // Dimension-unconstrained profiles accept any size.
+        expect(checkExtendSource(grok, sourceFile(), srcMeta(8, 854, 480)).wrongDimensions).toBe(false);
+    });
+
+    it('treats zero dimensions (probe could not read them) as unknown, not a violation', () => {
+        expect(checkExtendSource(veo, sourceFile(), srcMeta(8, 0, 0)).wrongDimensions).toBe(false);
+    });
+
+    it('treats unknown metadata as neither accepted nor blocked on probed constraints', () => {
         const check = checkExtendSource(grok, sourceFile(), null);
         expect(check.tooShort).toBe(false);
         expect(check.tooLong).toBe(false);
         expect(check.accepted).toBe(false);
         expect(check.blocked).toBe(false);
-        // File-level violations still block even with unknown duration.
+        expect(checkExtendSource(veo, sourceFile(), null).wrongDimensions).toBe(false);
+        // File-level violations still block even with unknown metadata.
         expect(checkExtendSource(grok, sourceFile({ type: 'video/webm', name: 'c.webm' }), null).blocked).toBe(true);
     });
 });

--- a/src/services/extendVideoCapabilities.ts
+++ b/src/services/extendVideoCapabilities.ts
@@ -64,8 +64,24 @@ export interface ExtendCapabilityProfile {
      * them for display only.
      */
     sourceMimeTypes: string[];
-    /** Extra source constraint shown on the accepted chip (e.g. "MP4 · ≤ 50 MiB"). */
+    /**
+     * Exact pixel dimensions the source must have; empty = unconstrained.
+     * Veo only extends its own output sizes (720p/1080p in 16:9 or 9:16),
+     * so the probed width×height is checked against this list.
+     */
+    sourceDimensions: Array<{ width: number; height: number }>;
+    /**
+     * Client-checkable source constraints shown on the accepted chip
+     * (e.g. "MP4 · ≤ 50 MiB"). Everything named here should be enforced
+     * by `checkExtendSource` (codec details being the documented exception).
+     */
     sourceNote?: string;
+    /**
+     * A requirement that cannot be verified client-side (Veo's "must be a
+     * Veo-created clip"). Always shown as a neutral requirement, never as
+     * part of an acceptance claim.
+     */
+    sourceRequirementNote?: string;
     /** Draft tier: 720p-only preview that also returns a reusable draft_cache. */
     isDraft: boolean;
 }
@@ -99,6 +115,7 @@ function flux3ExtendProfile(overrides: Partial<ExtendCapabilityProfile>): Extend
         sourceMaxSeconds: 15,
         sourceMaxBytes: 50_000_000,
         sourceMimeTypes: ['video/mp4'],
+        sourceDimensions: [],
         isDraft: false,
         ...overrides,
     };
@@ -130,11 +147,19 @@ function veo31ExtendProfile(): ExtendCapabilityProfile {
         promptRequired: true,
         sourceMinSeconds: null,
         sourceMaxSeconds: null,
-        // The real constraint is provenance (a Veo-created clip), which
-        // can't be checked client-side — no size or container gates.
         sourceMaxBytes: null,
         sourceMimeTypes: [],
-        sourceNote: 'Veo-created · 720p/1080p · 16:9 or 9:16',
+        // Veo only extends its own output sizes — the probed dimensions are
+        // checked against these. Provenance (a Veo-created clip) can't be
+        // verified client-side, so it's surfaced as a requirement instead.
+        sourceDimensions: [
+            { width: 1280, height: 720 },
+            { width: 1920, height: 1080 },
+            { width: 720, height: 1280 },
+            { width: 1080, height: 1920 },
+        ],
+        sourceNote: '720p/1080p · 16:9 or 9:16',
+        sourceRequirementNote: 'Requires a Veo-created source clip (not verifiable here)',
         isDraft: false,
     };
 }
@@ -162,6 +187,7 @@ const PROFILES: Record<string, ExtendCapabilityProfile> = {
         sourceMaxSeconds: null,
         sourceMaxBytes: null,
         sourceMimeTypes: [],
+        sourceDimensions: [],
         isDraft: false,
     },
     // Source clip: MP4, under 50 MB and under 15 seconds.
@@ -198,6 +224,7 @@ const PROFILES: Record<string, ExtendCapabilityProfile> = {
         sourceMaxSeconds: 15,
         sourceMaxBytes: null,
         sourceMimeTypes: ['video/mp4'],
+        sourceDimensions: [],
         sourceNote: 'MP4 (H.264/H.265/AV1)',
         isDraft: false,
     },
@@ -236,46 +263,62 @@ function matchesContainer(file: Pick<File, 'type' | 'name'>, required: string[])
     });
 }
 
+/** The probed source properties checkExtendSource can validate; null = probe pending/failed. */
+export interface ExtendSourceMetadata {
+    duration: number;
+    width: number;
+    height: number;
+}
+
 export interface ExtendSourceCheck {
     tooShort: boolean;
     tooLong: boolean;
     tooLarge: boolean;
     wrongContainer: boolean;
+    wrongDimensions: boolean;
     /** Any hard violation — generation should be blocked. */
     blocked: boolean;
     /**
-     * Duration is known and every client-checkable constraint passes.
-     * Not the negation of `blocked`: an unknown duration is neither.
+     * Metadata is known and every client-checkable constraint passes.
+     * Not the negation of `blocked`: unknown metadata is neither.
      */
     accepted: boolean;
 }
 
 /**
  * Validate a source clip against everything the profile can check
- * client-side: duration bounds (when known), file size, and container.
- * Codecs are not inspected — the API remains the final validator there.
- * Shared by the chips, the Generate gating, and the hook's pre-upload check
- * so the three never disagree.
+ * client-side: duration bounds and pixel dimensions (when the probe
+ * succeeded), file size, and container. Codecs and provenance are not
+ * inspected — the API remains the final validator there. Shared by the
+ * chips, the Generate gating, and the hook's pre-upload check so the
+ * three never disagree.
  */
 export function checkExtendSource(
     profile: ExtendCapabilityProfile,
     file: Pick<File, 'size' | 'type' | 'name'>,
-    durationSeconds: number | null,
+    meta: ExtendSourceMetadata | null,
 ): ExtendSourceCheck {
-    const tooShort =
-        profile.sourceMinSeconds !== null && durationSeconds !== null && durationSeconds < profile.sourceMinSeconds;
-    const tooLong =
-        profile.sourceMaxSeconds !== null && durationSeconds !== null && durationSeconds > profile.sourceMaxSeconds;
+    const tooShort = profile.sourceMinSeconds !== null && meta !== null && meta.duration < profile.sourceMinSeconds;
+    const tooLong = profile.sourceMaxSeconds !== null && meta !== null && meta.duration > profile.sourceMaxSeconds;
     const tooLarge = profile.sourceMaxBytes !== null && file.size > profile.sourceMaxBytes;
     const wrongContainer = profile.sourceMimeTypes.length > 0 && !matchesContainer(file, profile.sourceMimeTypes);
-    const blocked = tooShort || tooLong || tooLarge || wrongContainer;
+    // Dimensions can be 0 when the codec hides them from the probe — treat
+    // that as unknown rather than a violation.
+    const wrongDimensions =
+        profile.sourceDimensions.length > 0 &&
+        meta !== null &&
+        meta.width > 0 &&
+        meta.height > 0 &&
+        !profile.sourceDimensions.some((d) => d.width === meta.width && d.height === meta.height);
+    const blocked = tooShort || tooLong || tooLarge || wrongContainer || wrongDimensions;
     return {
         tooShort,
         tooLong,
         tooLarge,
         wrongContainer,
+        wrongDimensions,
         blocked,
-        accepted: durationSeconds !== null && !blocked,
+        accepted: meta !== null && !blocked,
     };
 }
 

--- a/src/services/extendVideoCapabilities.ts
+++ b/src/services/extendVideoCapabilities.ts
@@ -36,8 +36,19 @@ export interface ExtendCapabilityProfile {
     aspectRatios: string[];
     /** Whether the input schema has `generate_audio`. */
     supportsGenerateAudio: boolean;
-    /** Whether the input schema has integer `safety_tolerance` (0-4, default 2). */
-    supportsSafetyTolerance: boolean;
+    /**
+     * `safety_tolerance` levels in ascending order; empty = no such input.
+     * FLUX takes integers 0-4, Veo takes the digits as strings "1"-"6" —
+     * `safetyToleranceFormat` picks the wire type.
+     */
+    safetyToleranceValues: number[];
+    safetyToleranceFormat: 'integer' | 'string';
+    /** Whether the input schema has `negative_prompt`. */
+    supportsNegativePrompt: boolean;
+    /** Whether the input schema has `seed`. */
+    supportsSeed: boolean;
+    /** Whether the input schema has `auto_fix` (rewrite prompts that fail content policy). */
+    supportsAutoFix: boolean;
     /** Whether `prompt` is required (FLUX) or optional (LTX 2.3 Pro). */
     promptRequired: boolean;
     /** Minimum source clip length in seconds, or null when unconstrained (Grok: 2s). */
@@ -78,7 +89,11 @@ function flux3ExtendProfile(overrides: Partial<ExtendCapabilityProfile>): Extend
         resolutions: ['720p', '1080p'],
         aspectRatios: FLUX_3_EXTEND_ASPECT_RATIOS,
         supportsGenerateAudio: true,
-        supportsSafetyTolerance: true,
+        safetyToleranceValues: [0, 1, 2, 3, 4],
+        safetyToleranceFormat: 'integer',
+        supportsNegativePrompt: false,
+        supportsSeed: false,
+        supportsAutoFix: false,
         promptRequired: true,
         sourceMinSeconds: null,
         sourceMaxSeconds: 15,
@@ -86,6 +101,41 @@ function flux3ExtendProfile(overrides: Partial<ExtendCapabilityProfile>): Extend
         sourceMimeTypes: ['video/mp4'],
         isDraft: false,
         ...overrides,
+    };
+}
+
+/**
+ * Shared Veo 3.1 extend schema (fast and standard tiers are identical; only
+ * pricing differs). Duration and resolution are unconstrained strings in the
+ * schema — the extension is a fixed "7s" per pass (min === max, so the field
+ * is omitted and the server default applies). The source must itself be a
+ * Veo-created 720p/1080p clip in 16:9 or 9:16, chaining up to 30s total.
+ */
+function veo31ExtendProfile(): ExtendCapabilityProfile {
+    return {
+        durationMin: 7,
+        durationMax: 7,
+        durationStep: 1,
+        supportsAutoDuration: false,
+        supportsMode: false,
+        supportsContext: false,
+        resolutions: ['720p', '1080p'],
+        aspectRatios: ['auto', '16:9', '9:16'],
+        supportsGenerateAudio: true,
+        safetyToleranceValues: [1, 2, 3, 4, 5, 6],
+        safetyToleranceFormat: 'string',
+        supportsNegativePrompt: true,
+        supportsSeed: true,
+        supportsAutoFix: true,
+        promptRequired: true,
+        sourceMinSeconds: null,
+        sourceMaxSeconds: null,
+        // The real constraint is provenance (a Veo-created clip), which
+        // can't be checked client-side — no size or container gates.
+        sourceMaxBytes: null,
+        sourceMimeTypes: [],
+        sourceNote: 'Veo-created · 720p/1080p · 16:9 or 9:16',
+        isDraft: false,
     };
 }
 
@@ -102,7 +152,11 @@ const PROFILES: Record<string, ExtendCapabilityProfile> = {
         resolutions: [],
         aspectRatios: [],
         supportsGenerateAudio: false,
-        supportsSafetyTolerance: false,
+        safetyToleranceValues: [],
+        safetyToleranceFormat: 'integer',
+        supportsNegativePrompt: false,
+        supportsSeed: false,
+        supportsAutoFix: false,
         promptRequired: false,
         sourceMinSeconds: null,
         sourceMaxSeconds: null,
@@ -134,7 +188,11 @@ const PROFILES: Record<string, ExtendCapabilityProfile> = {
         resolutions: [],
         aspectRatios: [],
         supportsGenerateAudio: false,
-        supportsSafetyTolerance: false,
+        safetyToleranceValues: [],
+        safetyToleranceFormat: 'integer',
+        supportsNegativePrompt: false,
+        supportsSeed: false,
+        supportsAutoFix: false,
         promptRequired: true,
         sourceMinSeconds: 2,
         sourceMaxSeconds: 15,
@@ -143,9 +201,11 @@ const PROFILES: Record<string, ExtendCapabilityProfile> = {
         sourceNote: 'MP4 (H.264/H.265/AV1)',
         isDraft: false,
     },
+    // Veo 3.1 extend: fast and standard share one schema (pricing differs).
+    'fal-ai/veo3.1/extend-video': veo31ExtendProfile(),
+    'fal-ai/veo3.1/fast/extend-video': veo31ExtendProfile(),
     // fal-ai/ltx-2.3-quality and ltx-2.3-22b extend are frame-based APIs
     // (num_frames/num_context_frames, 19B-style knobs) — deferred.
-    // fal-ai/veo3.1 extend lands in the next stack layer.
 };
 
 /**

--- a/src/services/videoModels.ts
+++ b/src/services/videoModels.ts
@@ -482,6 +482,22 @@ export const CURATED_EXTEND_VIDEO_MODELS: ModelConfig[] = [
         supportsImageInput: false,
         outputType: 'video',
     },
+    {
+        endpointId: 'fal-ai/veo3.1/extend-video',
+        displayName: 'Veo 3.1 Extend',
+        category: 'extend-video',
+        description: 'Extend Veo-created clips by 7s per pass, up to 30s total',
+        supportsImageInput: false,
+        outputType: 'video',
+    },
+    {
+        endpointId: 'fal-ai/veo3.1/fast/extend-video',
+        displayName: 'Veo 3.1 Fast Extend',
+        category: 'extend-video',
+        description: 'Fast tier of Veo 3.1 extend — same 7s passes at lower cost',
+        supportsImageInput: false,
+        outputType: 'video',
+    },
 ];
 
 /** All curated video models */


### PR DESCRIPTION
Profile fal-ai/veo3.1/extend-video and /fast/extend-video — identical
schemas, only pricing differs. Veo forced two profile generalizations:

- Fixed-length passes: duration is an unconstrained string defaulting to
  "7s" with no enum, expressed as durationMin === durationMax. The panel
  shows "(fixed 7s per pass)" with no slider, the timeline band is
  locked at +7s, and the hook omits the field so the server default
  applies.
- safety_tolerance scales differ per family: supportsSafetyTolerance
  became safetyToleranceValues (ascending levels; empty = no input) plus
  safetyToleranceFormat — FLUX sends integers 0-4, Veo the digit as a
  string "1"-"6". The stored level is clamped into the active range.

New profile-gated rows for Veo's remaining inputs: negative_prompt and
seed (reusing videoNegativePrompt/videoSeed), and auto_fix (new
persisted extendAutoFix, only sent when enabled). The source constraint
is provenance, not length — "Veo-created, 720p/1080p, 16:9 or 9:16" —
carried on the accepted chip via sourceNote.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>