### PR TITLE
refactor(video): decompose generateVideo into pure services

### DIFF
--- a/src/hooks/useVideoGeneration.ts
+++ b/src/hooks/useVideoGeneration.ts
@@ -1,20 +1,23 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { fal } from '@fal-ai/client';
 import type { GenerationMode } from '../components/GenerationTabs';
 import type { ModelConfig } from '../types/models';
 import type { ConfigState } from '../config';
 import { parseFalError } from '../services/errors';
 import { getImageInputConfig } from '../services/modelParams';
-import { activeLongDurationConstraint, getVideoCapabilityProfile } from '../services/videoModelCapabilities';
 import {
-    checkExtendSource,
-    formatSourceMaxBytes,
+    describeExtendSourceViolation,
     getExtendCapabilityProfile,
-    snapExtendDuration,
+    type ExtendCapabilityProfile,
     type ExtendSourceMetadata,
 } from '../services/extendVideoCapabilities';
-import { isSeedanceModel } from '../services/videoModels';
+import { uploadFilesToFalStorage } from '../services/falStorage';
 import { FalQueueCancelledError, FalQueueTimeoutError, submitAndPollFalQueue } from '../services/falQueue';
+import {
+    buildVideoGenerationInput,
+    extractVideoUrl,
+    validateVideoRequest,
+    type VideoAssetUrls,
+} from '../services/videoInputBuilders';
 import { probeVideoFile } from '../utils/videoMetadata';
 import type { StatusType } from './useStatusMessage';
 
@@ -37,8 +40,79 @@ export interface UseVideoGenerationReturn {
 }
 
 /**
- * Hook for video generation using fal.ai API.
- * Handles queue submission, polling, and model-specific parameter routing.
+ * Probe the source clip when the profile has constraints only metadata can
+ * check. Returns null when nothing needs probing or the metadata is locally
+ * unreadable — the API remains the final validator of the upload.
+ */
+async function probeExtendSource(profile: ExtendCapabilityProfile, file: File): Promise<ExtendSourceMetadata | null> {
+    const needsProbe =
+        profile.sourceMinSeconds !== null || profile.sourceMaxSeconds !== null || profile.sourceDimensions.length > 0;
+    if (!needsProbe) {
+        return null;
+    }
+    try {
+        return await probeVideoFile(file, { capturePoster: false });
+    } catch {
+        return null;
+    }
+}
+
+interface UploadVideoAssetsArgs {
+    mode: GenerationMode;
+    modelId: string;
+    modelName: string;
+    images: File[];
+    videoFile: File | null;
+    onStatus: (message: string) => void;
+}
+
+/**
+ * Upload the media the active mode needs. Returns the resulting URLs, or a
+ * user-ready error message when an upload fails.
+ */
+async function uploadVideoAssets({
+    mode,
+    modelId,
+    modelName,
+    images,
+    videoFile,
+    onStatus,
+}: UploadVideoAssetsArgs): Promise<{ assets: VideoAssetUrls } | { error: string }> {
+    const assets: VideoAssetUrls = { referenceImageUrls: [] };
+    let label = 'media';
+    try {
+        if (mode === 'image-to-video' && images.length > 0) {
+            label = 'image';
+            // Start frame plus, on endpoints with a second upload slot
+            // (Seedance, MiniMax H3), the optional end frame — independent
+            // uploads, so they run in parallel.
+            const hasEndFrame = getImageInputConfig(modelId).maxImages >= 2 && images.length >= 2;
+            onStatus(`Uploading image${hasEndFrame ? 's' : ''} for ${modelName}...`);
+            const [imageUrl, endImageUrl] = await uploadFilesToFalStorage(images.slice(0, hasEndFrame ? 2 : 1));
+            assets.imageUrl = imageUrl;
+            assets.endImageUrl = endImageUrl;
+            onStatus(`Image uploaded. Submitting request for ${modelName}...`);
+        } else if (mode === 'reference-to-video' && images.length > 0) {
+            label = 'reference images';
+            onStatus(`Uploading ${images.length} reference image(s) for ${modelName}...`);
+            assets.referenceImageUrls = await uploadFilesToFalStorage(images);
+            onStatus(`Reference images uploaded. Submitting request for ${modelName}...`);
+        } else if ((mode === 'video-to-video' || mode === 'extend-video') && videoFile) {
+            label = 'video';
+            onStatus(`Uploading video for ${modelName}...`);
+            [assets.videoUrl] = await uploadFilesToFalStorage([videoFile]);
+            onStatus(`Video uploaded. Submitting request for ${modelName}...`);
+        }
+    } catch (error: unknown) {
+        return { error: `Error uploading ${label}: ${error instanceof Error ? error.message : String(error)}` };
+    }
+    return { assets };
+}
+
+/**
+ * Hook for video generation using fal.ai API. Orchestrates the pipeline —
+ * validate → upload → build payload → submit/poll → extract result — with
+ * the per-endpoint payload rules in `services/videoInputBuilders.ts`.
  */
 export function useVideoGeneration({
     activeTab,
@@ -64,36 +138,18 @@ export function useVideoGeneration({
 
             const modelId = model.endpointId;
             const modelName = model.displayName;
-            const isImageToVideo = activeTab === 'image-to-video';
-            const isVideoToVideo = activeTab === 'video-to-video';
-            const isReferenceToVideo = activeTab === 'reference-to-video';
             const isExtendVideo = activeTab === 'extend-video';
             const extendProfile = isExtendVideo ? getExtendCapabilityProfile(modelId) : undefined;
 
-            // Prompt is required everywhere except extend endpoints whose
-            // profile marks it optional (LTX 2.3 Pro extends without one).
-            const promptOptional = isExtendVideo && extendProfile !== undefined && !extendProfile.promptRequired;
-            if (!prompt && !promptOptional) {
-                setStatus('Please enter a text prompt.', 'error');
-                console.error('Prompt text is empty. Cannot generate video.');
-                return;
-            }
-
-            // For image-to-video mode, require an uploaded image
-            if (isImageToVideo && uploadedImages.length === 0) {
-                setStatus('Please upload an image for image-to-video generation.', 'error');
-                return;
-            }
-
-            // For video-to-video and extend-video modes, require an uploaded video
-            if ((isVideoToVideo || isExtendVideo) && !uploadedVideoFile) {
-                setStatus('Please upload a video to extend or transform.', 'error');
-                return;
-            }
-
-            // For reference-to-video mode, require at least one reference image
-            if (isReferenceToVideo && uploadedImages.length === 0) {
-                setStatus('Please upload at least one reference image for reference-to-video generation.', 'error');
+            const validationError = validateVideoRequest({
+                mode: activeTab,
+                prompt,
+                extendProfile,
+                imageCount: uploadedImages.length,
+                hasVideo: uploadedVideoFile !== null,
+            });
+            if (validationError) {
+                setStatus(validationError, 'error');
                 return;
             }
 
@@ -102,482 +158,48 @@ export function useVideoGeneration({
             // paying for a storage upload. The UI disables Generate too, but
             // revalidate here in case its metadata probe lagged or failed.
             if (isExtendVideo && extendProfile && uploadedVideoFile) {
-                let sourceMeta: ExtendSourceMetadata | null = null;
-                const needsProbe =
-                    extendProfile.sourceMinSeconds !== null ||
-                    extendProfile.sourceMaxSeconds !== null ||
-                    extendProfile.sourceDimensions.length > 0;
-                if (needsProbe) {
-                    try {
-                        sourceMeta = await probeVideoFile(uploadedVideoFile);
-                    } catch {
-                        // Unreadable metadata locally — let the API validate the upload.
-                    }
-                }
-                const sourceCheck = checkExtendSource(extendProfile, uploadedVideoFile, sourceMeta);
-                if (sourceCheck.tooLong && sourceMeta !== null) {
-                    setStatus(
-                        `Source clip is ${sourceMeta.duration.toFixed(1)}s — over the ${extendProfile.sourceMaxSeconds}s limit for ${modelName}.`,
-                        'error',
-                    );
-                    return;
-                }
-                if (sourceCheck.tooShort && sourceMeta !== null) {
-                    setStatus(
-                        `Source clip is ${sourceMeta.duration.toFixed(1)}s — under the ${extendProfile.sourceMinSeconds}s minimum for ${modelName}.`,
-                        'error',
-                    );
-                    return;
-                }
-                if (sourceCheck.wrongDimensions && sourceMeta !== null) {
-                    setStatus(
-                        `Source is ${sourceMeta.width}×${sourceMeta.height} — ${modelName} needs ${extendProfile.sourceNote ?? 'a supported resolution'}.`,
-                        'error',
-                    );
-                    return;
-                }
-                if (sourceCheck.tooLarge && extendProfile.sourceMaxBytes !== null) {
-                    setStatus(
-                        `Source file is ${(uploadedVideoFile.size / 1_000_000).toFixed(1)} MB — over the ${formatSourceMaxBytes(extendProfile.sourceMaxBytes)} limit for ${modelName}.`,
-                        'error',
-                    );
-                    return;
-                }
-                if (sourceCheck.wrongContainer) {
-                    setStatus(`Source must be an MP4 file for ${modelName}.`, 'error');
+                const sourceMeta = await probeExtendSource(extendProfile, uploadedVideoFile);
+                const violation = describeExtendSourceViolation(
+                    extendProfile,
+                    uploadedVideoFile,
+                    sourceMeta,
+                    modelName,
+                );
+                if (violation) {
+                    setStatus(violation, 'error');
                     return;
                 }
             }
 
             setIsGenerating(true);
             setVideoUrl(null); // Clear previous video
-            console.log(`Generating video with model: ${modelName}`);
-
             setStatus(`Submitting request for video generation using ${modelName}...`);
-            console.log(`Submitting request for model: ${modelName}, prompt: ${prompt.substring(0, 50)}...`);
+            console.log(`Generating video with model: ${modelName}, prompt: ${prompt.substring(0, 50)}...`);
 
-            let uploadedImageUrl: string | undefined;
-            let uploadedEndImageUrl: string | undefined;
-            let uploadedReferenceImageUrls: string[] = [];
-            let uploadedVideoUrl: string | undefined;
-
-            // For image-to-video, upload the start frame (and optional end frame for seedance)
-            if (isImageToVideo && uploadedImages.length > 0) {
-                try {
-                    setStatus(`Uploading image for ${modelName}...`);
-                    uploadedImageUrl = await fal.storage.upload(uploadedImages[0]);
-                    console.log('Image uploaded successfully:', uploadedImageUrl);
-
-                    // I2V endpoints with a second upload slot (Seedance, MiniMax H3):
-                    // the optional second image becomes the end_image_url
-                    if (getImageInputConfig(modelId).maxImages >= 2 && uploadedImages.length >= 2) {
-                        setStatus(`Uploading end-frame image for ${modelName}...`);
-                        uploadedEndImageUrl = await fal.storage.upload(uploadedImages[1]);
-                        console.log('End-frame image uploaded successfully:', uploadedEndImageUrl);
-                    }
-
-                    setStatus(`Image uploaded. Submitting request for ${modelName}...`);
-                } catch (uploadError: unknown) {
-                    const errorMsg = `Error uploading image: ${uploadError instanceof Error ? uploadError.message : String(uploadError)}`;
-                    setStatus(errorMsg, 'error');
-                    console.error(errorMsg);
-                    setIsGenerating(false);
-                    return;
-                }
+            const uploadResult = await uploadVideoAssets({
+                mode: activeTab,
+                modelId,
+                modelName,
+                images: uploadedImages,
+                videoFile: uploadedVideoFile,
+                onStatus: setStatus,
+            });
+            if ('error' in uploadResult) {
+                setStatus(uploadResult.error, 'error');
+                console.error(uploadResult.error);
+                setIsGenerating(false);
+                return;
             }
+            const { assets } = uploadResult;
 
-            // For reference-to-video, upload all reference images
-            if (isReferenceToVideo && uploadedImages.length > 0) {
-                try {
-                    setStatus(`Uploading ${uploadedImages.length} reference image(s) for ${modelName}...`);
-                    uploadedReferenceImageUrls = await Promise.all(
-                        uploadedImages.map((file) => fal.storage.upload(file)),
-                    );
-                    console.log('Reference images uploaded:', uploadedReferenceImageUrls);
-                    setStatus(`Reference images uploaded. Submitting request for ${modelName}...`);
-                } catch (uploadError: unknown) {
-                    const errorMsg = `Error uploading reference images: ${uploadError instanceof Error ? uploadError.message : String(uploadError)}`;
-                    setStatus(errorMsg, 'error');
-                    console.error(errorMsg);
-                    setIsGenerating(false);
-                    return;
-                }
-            }
-
-            // For video-to-video and extend-video, upload the video first
-            if ((isVideoToVideo || isExtendVideo) && uploadedVideoFile) {
-                try {
-                    setStatus(`Uploading video for ${modelName}...`);
-                    uploadedVideoUrl = await fal.storage.upload(uploadedVideoFile);
-                    console.log('Video uploaded successfully:', uploadedVideoUrl);
-                    setStatus(`Video uploaded. Submitting request for ${modelName}...`);
-                } catch (uploadError: unknown) {
-                    const errorMsg = `Error uploading video: ${uploadError instanceof Error ? uploadError.message : String(uploadError)}`;
-                    setStatus(errorMsg, 'error');
-                    console.error(errorMsg);
-                    setIsGenerating(false);
-                    return;
-                }
-            }
-
-            // Build video generation input parameters
-            const input: Record<string, unknown> = {
+            const input = buildVideoGenerationInput({
+                modelId,
+                mode: activeTab,
                 prompt,
-            };
-
-            const modelIdLower = modelId.toLowerCase();
-            const isSeedance = isSeedanceModel(modelId);
-            // Capability profile (Seedance 2.5, MiniMax H3): declares which fields the
-            // endpoint's schema accepts, so the payload is built from data instead of
-            // per-model conditionals. Unprofiled endpoints use the legacy branches.
-            const profile = getVideoCapabilityProfile(modelId);
-
-            if (isExtendVideo) {
-                // Extend endpoints take the source clip plus range/constraint
-                // parameters from the ExtendCapabilityProfile. Unprofiled extend
-                // endpoints get only prompt + video_url (server defaults apply).
-                input.video_url = uploadedVideoUrl;
-
-                // LTX 2.3 Pro accepts requests without a prompt; drop the empty field.
-                if (!prompt) {
-                    delete input.prompt;
-                }
-
-                if (extendProfile) {
-                    // Duration: FLUX defaults to "auto" and Veo has a single fixed
-                    // length (min === max) — omit the field in both cases so the
-                    // server default applies. LTX always takes explicit float
-                    // seconds; whole-second endpoints get integers.
-                    const durationAuto = extendProfile.supportsAutoDuration && config.extendDurationAuto;
-                    const durationFixed = extendProfile.durationMin === extendProfile.durationMax;
-                    if (!durationAuto && !durationFixed) {
-                        // Snap to the profile step so the payload matches what
-                        // the panel displays (fractional carry-over from another
-                        // model must not round differently here).
-                        input.duration = snapExtendDuration(extendProfile, config.extendDuration);
-                    }
-
-                    if (extendProfile.supportsMode) {
-                        input.mode = config.extendMode === 'start' ? 'start' : 'end';
-                    }
-
-                    // Context: omitting the field maximizes available context server-side.
-                    if (extendProfile.supportsContext && !config.extendContextAuto) {
-                        input.context = Math.min(Math.max(config.extendContext, 1), 20);
-                    }
-
-                    if (extendProfile.resolutions.length > 0) {
-                        input.resolution = extendProfile.resolutions.includes(config.videoResolution)
-                            ? config.videoResolution
-                            : extendProfile.resolutions[0];
-                    }
-
-                    if (extendProfile.aspectRatios.length > 0) {
-                        input.aspect_ratio = extendProfile.aspectRatios.includes(config.extendAspectRatio)
-                            ? config.extendAspectRatio
-                            : extendProfile.aspectRatios[0];
-                    }
-
-                    if (extendProfile.supportsGenerateAudio) {
-                        input.generate_audio = config.generateAudio;
-                    }
-
-                    // Safety tolerance: clamp the stored level into the endpoint's
-                    // range; FLUX takes an integer, Veo the digit as a string.
-                    if (extendProfile.safetyToleranceValues.length > 0) {
-                        const values = extendProfile.safetyToleranceValues;
-                        const clamped = Math.min(
-                            Math.max(config.extendSafetyTolerance, values[0]),
-                            values[values.length - 1],
-                        );
-                        input.safety_tolerance =
-                            extendProfile.safetyToleranceFormat === 'string' ? String(clamped) : clamped;
-                    }
-
-                    if (extendProfile.supportsNegativePrompt && config.videoNegativePrompt) {
-                        input.negative_prompt = config.videoNegativePrompt;
-                    }
-
-                    if (extendProfile.supportsSeed && config.videoSeed !== null) {
-                        input.seed = config.videoSeed;
-                    }
-
-                    // auto_fix defaults to false server-side; only send when enabled.
-                    if (extendProfile.supportsAutoFix && config.extendAutoFix) {
-                        input.auto_fix = true;
-                    }
-                }
-            } else if (profile) {
-                if (config.videoResolution) {
-                    input.resolution = config.videoResolution;
-                }
-
-                // Duration comes from the profile's enum. Storage may hold a legacy
-                // "5s" suffix from other models; strip it before serializing.
-                if (config.videoDuration) {
-                    const raw = config.videoDuration.trim().replace(/s$/, '');
-                    if (profile.durationFormat === 'integer') {
-                        const seconds = parseInt(raw, 10);
-                        if (!Number.isNaN(seconds)) {
-                            input.duration = seconds;
-                        }
-                    } else {
-                        input.duration = raw;
-                    }
-                }
-
-                // Aspect ratio: omitted entirely when the schema has no such input
-                // (empty enum); a profile may pin it (Seedance 2.5 i2v only accepts "auto").
-                if (profile.forcedAspectRatio) {
-                    input.aspect_ratio = profile.forcedAspectRatio;
-                } else if (profile.aspectRatios.length > 0 && config.videoAspectRatio) {
-                    input.aspect_ratio = config.videoAspectRatio;
-                }
-
-                // FPS: integer field, only on endpoints whose schema declares an enum (LTX).
-                if (profile.fpsValues.length > 0 && config.videoFps) {
-                    const fps = parseInt(config.videoFps, 10);
-                    if (!Number.isNaN(fps)) {
-                        input.fps = fps;
-                    }
-                }
-
-                // Long durations can pin fps/resolution (LTX 2.3 Fast: 12s+ only
-                // runs at 25 fps, 1080p). The UI collapses the selectors too, but
-                // normalize here so a stale stored combination can't reach the API.
-                const durationConstraint = activeLongDurationConstraint(profile, config.videoDuration);
-                if (durationConstraint) {
-                    input.resolution = durationConstraint.resolution;
-                    if (profile.fpsValues.length > 0) {
-                        input.fps = parseInt(durationConstraint.fps, 10);
-                    }
-                }
-
-                // camera_motion is optional server-side; 'none' means omit it.
-                if (profile.cameraMotions.length > 0 && config.videoCameraMotion !== 'none') {
-                    input.camera_motion = config.videoCameraMotion;
-                }
-
-                if (profile.supportsGenerateAudio) {
-                    input.generate_audio = config.generateAudio;
-                }
-                if (profile.supportsSeed && config.videoSeed !== null) {
-                    input.seed = config.videoSeed;
-                }
-                if (profile.supportsNegativePrompt && config.videoNegativePrompt) {
-                    input.negative_prompt = config.videoNegativePrompt;
-                }
-                if (profile.supportsPromptExpansion) {
-                    input.enable_prompt_expansion = config.videoEnablePromptExpansion;
-                }
-                if (profile.supportsSafetyChecker) {
-                    input.enable_safety_checker = config.enableSafetyChecker;
-                }
-
-                // Mode-specific image inputs (start frame + optional end frame).
-                if (isImageToVideo && uploadedImageUrl) {
-                    input.image_url = uploadedImageUrl;
-                    if (uploadedEndImageUrl) {
-                        input.end_image_url = uploadedEndImageUrl;
-                    }
-                } else if (isReferenceToVideo && uploadedReferenceImageUrls.length > 0) {
-                    // Only Seedance 2.5 r2v is profiled today; it takes `image_urls`.
-                    input.image_urls = uploadedReferenceImageUrls;
-                }
-            } else if (isSeedance) {
-                // Seedance 2.0 has its own input shape (string `duration` enum, no cfg_scale,
-                // no guidance_scale, no fps). Build the payload here; the per-model branches
-                // below are gated so they don't fight with this.
-
-                // Resolution (Pro: 480p/720p/1080p; Fast: 480p/720p)
-                if (config.videoResolution) {
-                    input.resolution = config.videoResolution;
-                }
-
-                // Duration: seedance expects "auto" or a string "4".."15".
-                // Storage may have either a bare number ("5") or a legacy "5s" suffix.
-                if (config.videoDuration) {
-                    const raw = config.videoDuration.trim();
-                    input.duration = raw === 'auto' ? 'auto' : raw.replace(/s$/, '');
-                }
-
-                // Aspect ratio: pass through, including "auto" and "21:9".
-                if (config.videoAspectRatio) {
-                    input.aspect_ratio = config.videoAspectRatio;
-                }
-
-                // Synchronized audio (default true on the API; we mirror the user's toggle).
-                input.generate_audio = config.generateAudio;
-
-                // Seed (optional integer).
-                if (config.videoSeed !== null) {
-                    input.seed = config.videoSeed;
-                }
-
-                // Mode-specific image inputs.
-                if (isImageToVideo && uploadedImageUrl) {
-                    input.image_url = uploadedImageUrl;
-                    if (uploadedEndImageUrl) {
-                        input.end_image_url = uploadedEndImageUrl;
-                    }
-                } else if (isReferenceToVideo && uploadedReferenceImageUrls.length > 0) {
-                    input.image_urls = uploadedReferenceImageUrls;
-                }
-            } else {
-                // --- Non-seedance video models share the legacy parameter routing below ---
-
-                // Add image_url for image-to-video models
-                if (isImageToVideo && uploadedImageUrl) {
-                    input.image_url = uploadedImageUrl;
-                }
-
-                // Add video_url for video-to-video models
-                if (isVideoToVideo && uploadedVideoUrl) {
-                    input.video_url = uploadedVideoUrl;
-                }
-
-                // Add duration (parse to number if model expects seconds)
-                if (config.videoDuration) {
-                    const durationNum = parseInt(config.videoDuration.replace('s', ''), 10);
-                    input.duration = durationNum || config.videoDuration;
-                }
-
-                // Add aspect ratio
-                if (config.videoAspectRatio) {
-                    input.aspect_ratio = config.videoAspectRatio;
-                }
-
-                // Add resolution if supported
-                if (config.videoResolution) {
-                    input.resolution = config.videoResolution;
-                }
-            }
-
-            // Model detection for specific parameters (legacy routing — skipped for
-            // extend mode, profiled endpoints, and seedance, whose input shapes are
-            // built above).
-            if (!isExtendVideo && !isSeedance && !profile) {
-                const isKlingModel = modelIdLower.includes('kling');
-                const isVeoModel = modelIdLower.includes('veo');
-                const isLtx19bModel = modelIdLower.includes('ltx-2-19b');
-                const isLtxProFastModel = modelIdLower.includes('ltx-2') && !modelIdLower.includes('ltx-2-19b');
-                const isLtxModel = modelIdLower.includes('ltx-2');
-                const isGrokVideoModel = modelIdLower.includes('grok-imagine-video');
-                const isGrokVideoEdit =
-                    modelIdLower.includes('grok-imagine-video') && modelIdLower.includes('edit-video');
-                const supportsAudio = isVeoModel || isLtxModel;
-                const supportsGuidanceScale =
-                    isLtx19bModel || (!isVeoModel && !isLtxProFastModel && !isKlingModel && !isGrokVideoModel);
-
-                // V2V model detection
-                const isVideoToVideoMode = activeTab === 'video-to-video';
-                const isMMAudioModel = modelIdLower.includes('mmaudio');
-                const isBriaBgRemoval = modelIdLower.includes('bria') && modelIdLower.includes('background-removal');
-                const isLtx19bV2V = isLtx19bModel && modelIdLower.includes('video-to-video');
-                const isWanV2V = modelIdLower.includes('wan') && modelIdLower.includes('video-to-video');
-                const isHunyuanV2V = modelIdLower.includes('hunyuan') && modelIdLower.includes('video-to-video');
-                const isAnimateDiffV2V =
-                    modelIdLower.includes('animatediff') && modelIdLower.includes('video-to-video');
-
-                // Add CFG scale for Kling models (0-1 range)
-                if (isKlingModel) {
-                    input.cfg_scale = config.videoCfgScale;
-                }
-
-                // Add guidance scale only for models that support it
-                if (supportsGuidanceScale && config.videoGuidanceScale > 0) {
-                    input.guidance_scale = config.videoGuidanceScale;
-                }
-
-                // Add generate_audio for veo and ltx-2 models
-                if (supportsAudio) {
-                    input.generate_audio = config.generateAudio;
-                }
-
-                // Add fps for LTX-2 Pro/Fast models
-                if (isLtxProFastModel) {
-                    input.fps = parseInt(config.videoFps, 10);
-                }
-
-                // Grok Imagine Video specific parameters
-                if (isGrokVideoModel) {
-                    // Grok uses continuous duration (1-15s), parse from config
-                    if (config.videoDuration) {
-                        const durationNum = parseInt(config.videoDuration.replace('s', ''), 10);
-                        input.duration = Math.min(15, Math.max(1, durationNum));
-                    }
-
-                    // Grok video resolution (480p or 720p only, or 'auto' for edit-video)
-                    if (config.videoResolution) {
-                        const res = config.videoResolution;
-                        if (isGrokVideoEdit) {
-                            // Edit video supports auto/480p/720p
-                            input.resolution = res === '480p' || res === '720p' ? res : 'auto';
-                        } else {
-                            // Text/image to video only supports 480p/720p
-                            input.resolution = res === '480p' || res === '720p' ? res : '720p';
-                        }
-                    }
-
-                    // Grok doesn't use guidance_scale, remove if accidentally set
-                    delete input.guidance_scale;
-                }
-
-                // LTX-2 19B specific parameters
-                if (isLtx19bModel) {
-                    input.num_frames = config.videoNumFrames;
-                    input.video_size = config.videoOutputSize;
-                    input.use_multiscale = config.videoUseMultiscale;
-                    input.num_inference_steps = config.videoNumInferenceSteps;
-                    input.acceleration = config.videoAcceleration;
-                    input.enable_prompt_expansion = config.videoEnablePromptExpansion;
-
-                    // Camera LoRA only if not 'none'
-                    if (config.videoCameraLora !== 'none') {
-                        input.camera_lora = config.videoCameraLora;
-                        input.camera_lora_scale = config.videoCameraLoraScale;
-                    }
-
-                    // LTX-2 19B doesn't use duration/resolution
-                    delete input.duration;
-                    delete input.resolution;
-                }
-
-                // Add seed if set
-                if (config.videoSeed !== null) {
-                    input.seed = config.videoSeed;
-                }
-
-                // Add negative prompt if set
-                if (config.videoNegativePrompt) {
-                    input.negative_prompt = config.videoNegativePrompt;
-                }
-
-                // V2V model-specific parameters
-
-                // Video strength for V2V transformation
-                if (isVideoToVideoMode && (isLtx19bV2V || isWanV2V || isHunyuanV2V || isAnimateDiffV2V)) {
-                    input.strength = config.videoStrength;
-                }
-
-                // Preprocessor for LTX-2 19B V2V
-                if (isLtx19bV2V && config.videoPreprocessor !== 'none') {
-                    input.preprocessor = config.videoPreprocessor;
-                }
-
-                // MMAudio V2 parameters
-                if (isMMAudioModel) {
-                    input.cfg_strength = config.mmAudioCfgStrength;
-                    input.num_steps = config.mmAudioNumSteps;
-                    // Duration is handled separately above
-                }
-
-                // Bria Background Removal parameters
-                if (isBriaBgRemoval) {
-                    input.background_color = config.briaBgColor;
-                    input.output_container_and_codec = config.briaOutputCodec;
-                }
-            }
+                config,
+                assets,
+                extendProfile,
+            });
 
             try {
                 console.log(`Input sent to API for model ${modelName}:`, input);
@@ -591,21 +213,7 @@ export function useVideoGeneration({
                     timeoutMs: POLL_TIMEOUT_MS,
                 });
 
-                // Video response can have different structures
-                let videoResultUrl: string | undefined;
-
-                if (data.video) {
-                    if (typeof data.video === 'string') {
-                        videoResultUrl = data.video;
-                    } else if (typeof data.video === 'object' && data.video !== null) {
-                        const videoObj = data.video as { url?: string };
-                        videoResultUrl = videoObj.url;
-                    }
-                } else if (Array.isArray(data.videos) && data.videos.length > 0) {
-                    const firstVideo = data.videos[0] as { url?: string } | string;
-                    videoResultUrl = typeof firstVideo === 'string' ? firstVideo : firstVideo.url;
-                }
-
+                const videoResultUrl = extractVideoUrl(data);
                 if (videoResultUrl) {
                     console.log(`Video generated successfully:`, videoResultUrl);
                     setVideoUrl(videoResultUrl);
@@ -626,8 +234,6 @@ export function useVideoGeneration({
                 }
                 console.error('Video generation error:', error);
 
-                const parsedError = parseFalError(error);
-
                 const rawMessage = error instanceof Error ? error.message : String(error);
                 if (rawMessage.includes('401') || rawMessage.includes('Unauthorized')) {
                     console.error(
@@ -635,7 +241,7 @@ export function useVideoGeneration({
                     );
                     setStatus('Authentication failed. Please check your API key.', 'error');
                 } else {
-                    setStatus(parsedError, 'error');
+                    setStatus(parseFalError(error), 'error');
                 }
             } finally {
                 setIsGenerating(false);

--- a/src/services/extendVideoCapabilities.ts
+++ b/src/services/extendVideoCapabilities.ts
@@ -328,6 +328,37 @@ export function formatSourceMaxBytes(bytes: number): string {
 }
 
 /**
+ * Human-readable reason a source clip is rejected, or null when every
+ * client-checkable constraint passes. Lives beside `checkExtendSource` so
+ * the wording stays with the predicates it describes and every consumer
+ * (hook, chips) reports the same violation the same way.
+ */
+export function describeExtendSourceViolation(
+    profile: ExtendCapabilityProfile,
+    file: Pick<File, 'size' | 'type' | 'name'>,
+    meta: ExtendSourceMetadata | null,
+    modelName: string,
+): string | null {
+    const check = checkExtendSource(profile, file, meta);
+    if (check.tooLong && meta !== null) {
+        return `Source clip is ${meta.duration.toFixed(1)}s — over the ${profile.sourceMaxSeconds}s limit for ${modelName}.`;
+    }
+    if (check.tooShort && meta !== null) {
+        return `Source clip is ${meta.duration.toFixed(1)}s — under the ${profile.sourceMinSeconds}s minimum for ${modelName}.`;
+    }
+    if (check.wrongDimensions && meta !== null) {
+        return `Source is ${meta.width}×${meta.height} — ${modelName} needs ${profile.sourceNote ?? 'a supported resolution'}.`;
+    }
+    if (check.tooLarge && profile.sourceMaxBytes !== null) {
+        return `Source file is ${(file.size / 1_000_000).toFixed(1)} MB — over the ${formatSourceMaxBytes(profile.sourceMaxBytes)} limit for ${modelName}.`;
+    }
+    if (check.wrongContainer) {
+        return `Source must be an MP4 file for ${modelName}.`;
+    }
+    return null;
+}
+
+/**
  * Clamp a persisted extension length into the profile's bounds and snap it
  * to the slider step, so a fractional value carried over from another model
  * (LTX allows 2.5s) can't display one number while a whole-second endpoint

--- a/src/services/falStorage.ts
+++ b/src/services/falStorage.ts
@@ -1,0 +1,10 @@
+import { fal } from '@fal-ai/client';
+
+/**
+ * Upload local files to fal storage in parallel, returning their public URLs
+ * in the same order. Shared by the generation hooks so upload behavior
+ * (parallelism, future retries or size checks) lives in one place.
+ */
+export async function uploadFilesToFalStorage(files: File[]): Promise<string[]> {
+    return Promise.all(files.map((file) => fal.storage.upload(file)));
+}

--- a/src/services/videoInputBuilders.test.ts
+++ b/src/services/videoInputBuilders.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it } from 'vitest';
+import type { ConfigState } from '../config';
+import type { ExtendCapabilityProfile } from './extendVideoCapabilities';
+import { getExtendCapabilityProfile } from './extendVideoCapabilities';
+import type { VideoCapabilityProfile } from './videoModelCapabilities';
+import {
+    buildExtendVideoInput,
+    buildLegacyVideoInput,
+    buildProfiledVideoInput,
+    buildSeedanceVideoInput,
+    buildVideoGenerationInput,
+    extractVideoUrl,
+    validateVideoRequest,
+    type VideoAssetUrls,
+} from './videoInputBuilders';
+
+/** Video-relevant config defaults; tests override only what they exercise. */
+const cfg = (overrides: Partial<ConfigState> = {}): ConfigState =>
+    ({
+        videoDuration: '5s',
+        videoAspectRatio: '16:9',
+        videoResolution: '720p',
+        videoGuidanceScale: 0,
+        videoSeed: null,
+        videoNegativePrompt: '',
+        generateAudio: true,
+        videoCfgScale: 0.5,
+        videoFps: '25',
+        videoCameraMotion: 'none',
+        videoNumFrames: 121,
+        videoOutputSize: 'landscape_4_3',
+        videoUseMultiscale: true,
+        videoNumInferenceSteps: 40,
+        videoAcceleration: 'regular',
+        videoCameraLora: 'none',
+        videoCameraLoraScale: 1,
+        videoEnablePromptExpansion: false,
+        enableSafetyChecker: true,
+        videoStrength: 0.8,
+        videoPreprocessor: 'none',
+        extendDuration: 5,
+        extendDurationAuto: false,
+        extendMode: 'end',
+        extendContext: 5,
+        extendContextAuto: true,
+        extendAspectRatio: 'auto',
+        extendSafetyTolerance: 2,
+        extendAutoFix: false,
+        mmAudioCfgStrength: 4.5,
+        mmAudioNumSteps: 25,
+        briaBgColor: 'transparent',
+        briaOutputCodec: 'mp4_h264',
+        ...overrides,
+    }) as ConfigState;
+
+const noAssets: VideoAssetUrls = { referenceImageUrls: [] };
+
+const bareProfile = (overrides: Partial<VideoCapabilityProfile> = {}): VideoCapabilityProfile => ({
+    durations: ['5', '10'],
+    durationFormat: 'string',
+    resolutions: ['720p', '480p'],
+    aspectRatios: ['16:9', '9:16'],
+    fpsValues: [],
+    cameraMotions: [],
+    supportsSeed: false,
+    supportsNegativePrompt: false,
+    supportsGenerateAudio: false,
+    supportsPromptExpansion: false,
+    supportsSafetyChecker: false,
+    ...overrides,
+});
+
+describe('validateVideoRequest', () => {
+    const base = {
+        prompt: 'a prompt',
+        extendProfile: undefined as ExtendCapabilityProfile | undefined,
+        imageCount: 0,
+        hasVideo: false,
+    };
+
+    it('requires a prompt for standard modes', () => {
+        expect(validateVideoRequest({ ...base, mode: 'text-to-video', prompt: '' })).toMatch(/text prompt/);
+        expect(validateVideoRequest({ ...base, mode: 'text-to-video' })).toBeNull();
+    });
+
+    it('lets a prompt-optional extend profile skip the prompt requirement', () => {
+        const ltx = getExtendCapabilityProfile('fal-ai/ltx-2.3/extend-video');
+        expect(
+            validateVideoRequest({ ...base, mode: 'extend-video', prompt: '', extendProfile: ltx, hasVideo: true }),
+        ).toBeNull();
+        // Unprofiled extend endpoints still require a prompt
+        expect(validateVideoRequest({ ...base, mode: 'extend-video', prompt: '', hasVideo: true })).toMatch(
+            /text prompt/,
+        );
+    });
+
+    it('requires the mode-specific media', () => {
+        expect(validateVideoRequest({ ...base, mode: 'image-to-video' })).toMatch(/upload an image/);
+        expect(validateVideoRequest({ ...base, mode: 'image-to-video', imageCount: 1 })).toBeNull();
+        expect(validateVideoRequest({ ...base, mode: 'video-to-video' })).toMatch(/upload a video/);
+        expect(validateVideoRequest({ ...base, mode: 'extend-video' })).toMatch(/upload a video/);
+        expect(validateVideoRequest({ ...base, mode: 'reference-to-video' })).toMatch(/reference image/);
+    });
+});
+
+describe('buildExtendVideoInput', () => {
+    it('sends only prompt + video_url for unprofiled endpoints', () => {
+        expect(buildExtendVideoInput(undefined, cfg(), 'go', 'https://v/clip.mp4')).toEqual({
+            prompt: 'go',
+            video_url: 'https://v/clip.mp4',
+        });
+    });
+
+    it('omits an empty prompt (LTX 2.3 Pro)', () => {
+        const ltx = getExtendCapabilityProfile('fal-ai/ltx-2.3/extend-video');
+        const input = buildExtendVideoInput(ltx, cfg(), '', 'url');
+        expect(input).not.toHaveProperty('prompt');
+        expect(input.video_url).toBe('url');
+    });
+
+    it('snaps duration to the profile step and sends mode/context for LTX', () => {
+        const ltx = getExtendCapabilityProfile('fal-ai/ltx-2.3/extend-video');
+        const input = buildExtendVideoInput(
+            ltx,
+            cfg({ extendDuration: 7.3, extendMode: 'start', extendContextAuto: false, extendContext: 30 }),
+            'go',
+            'url',
+        );
+        expect(input.duration).toBe(7.5);
+        expect(input.mode).toBe('start');
+        expect(input.context).toBe(20); // clamped into 1-20
+    });
+
+    it('omits duration on auto (FLUX) and on fixed-length profiles (Veo)', () => {
+        const flux = getExtendCapabilityProfile('blackforestlabs/flux-3/extend-video');
+        expect(buildExtendVideoInput(flux, cfg({ extendDurationAuto: true }), 'go', 'url')).not.toHaveProperty(
+            'duration',
+        );
+        const veo = getExtendCapabilityProfile('fal-ai/veo3.1/extend-video');
+        expect(buildExtendVideoInput(veo, cfg(), 'go', 'url')).not.toHaveProperty('duration');
+    });
+
+    it('snaps stale resolution/aspect into the profile enum', () => {
+        const flux = getExtendCapabilityProfile('blackforestlabs/flux-3/extend-video');
+        const input = buildExtendVideoInput(
+            flux,
+            cfg({ videoResolution: '480p', extendAspectRatio: '9:21' }),
+            'go',
+            'url',
+        );
+        expect(input.resolution).toBe('720p'); // 480p not in FLUX enum → default
+        expect(input.aspect_ratio).toBe('auto'); // 9:21 not in enum → default
+    });
+
+    it('serializes safety tolerance per the profile format', () => {
+        const flux = getExtendCapabilityProfile('blackforestlabs/flux-3/extend-video');
+        expect(buildExtendVideoInput(flux, cfg({ extendSafetyTolerance: 9 }), 'go', 'url').safety_tolerance).toBe(4);
+        const veo = getExtendCapabilityProfile('fal-ai/veo3.1/extend-video');
+        expect(buildExtendVideoInput(veo, cfg({ extendSafetyTolerance: 0 }), 'go', 'url').safety_tolerance).toBe('1');
+    });
+
+    it('sends Veo-only optional fields only when set', () => {
+        const veo = getExtendCapabilityProfile('fal-ai/veo3.1/extend-video');
+        const bare = buildExtendVideoInput(veo, cfg(), 'go', 'url');
+        expect(bare).not.toHaveProperty('negative_prompt');
+        expect(bare).not.toHaveProperty('seed');
+        expect(bare).not.toHaveProperty('auto_fix');
+
+        const full = buildExtendVideoInput(
+            veo,
+            cfg({ videoNegativePrompt: 'blur', videoSeed: 42, extendAutoFix: true }),
+            'go',
+            'url',
+        );
+        expect(full.negative_prompt).toBe('blur');
+        expect(full.seed).toBe(42);
+        expect(full.auto_fix).toBe(true);
+    });
+});
+
+describe('buildProfiledVideoInput', () => {
+    it('strips a legacy "5s" suffix and honors the duration format', () => {
+        const asString = buildProfiledVideoInput(bareProfile(), cfg(), 'text-to-video', 'go', noAssets);
+        expect(asString.duration).toBe('5');
+        const asInt = buildProfiledVideoInput(
+            bareProfile({ durationFormat: 'integer' }),
+            cfg(),
+            'text-to-video',
+            'go',
+            noAssets,
+        );
+        expect(asInt.duration).toBe(5);
+    });
+
+    it('pins a forced aspect ratio and omits the field when the enum is empty', () => {
+        const forced = buildProfiledVideoInput(
+            bareProfile({ forcedAspectRatio: 'auto' }),
+            cfg(),
+            'text-to-video',
+            'go',
+            noAssets,
+        );
+        expect(forced.aspect_ratio).toBe('auto');
+        const none = buildProfiledVideoInput(bareProfile({ aspectRatios: [] }), cfg(), 'text-to-video', 'go', noAssets);
+        expect(none).not.toHaveProperty('aspect_ratio');
+    });
+
+    it('applies the long-duration fps/resolution constraint over stored values', () => {
+        const profile = bareProfile({
+            fpsValues: ['25', '50'],
+            longDurationConstraint: { minDurationSeconds: 12, fps: '25', resolution: '1080p' },
+        });
+        const input = buildProfiledVideoInput(
+            profile,
+            cfg({ videoDuration: '12', videoFps: '50' }),
+            'text-to-video',
+            'go',
+            noAssets,
+        );
+        expect(input.resolution).toBe('1080p');
+        expect(input.fps).toBe(25);
+    });
+
+    it('sends optional fields only when the profile declares them', () => {
+        const config = cfg({ videoSeed: 7, videoNegativePrompt: 'blur' });
+        const bare = buildProfiledVideoInput(bareProfile(), config, 'text-to-video', 'go', noAssets);
+        expect(bare).not.toHaveProperty('seed');
+        expect(bare).not.toHaveProperty('negative_prompt');
+        expect(bare).not.toHaveProperty('generate_audio');
+
+        const full = buildProfiledVideoInput(
+            bareProfile({ supportsSeed: true, supportsNegativePrompt: true, supportsGenerateAudio: true }),
+            config,
+            'text-to-video',
+            'go',
+            noAssets,
+        );
+        expect(full.seed).toBe(7);
+        expect(full.negative_prompt).toBe('blur');
+        expect(full.generate_audio).toBe(true);
+    });
+
+    it('routes image assets per mode', () => {
+        const i2v = buildProfiledVideoInput(bareProfile(), cfg(), 'image-to-video', 'go', {
+            imageUrl: 'start',
+            endImageUrl: 'end',
+            referenceImageUrls: [],
+        });
+        expect(i2v.image_url).toBe('start');
+        expect(i2v.end_image_url).toBe('end');
+
+        const r2v = buildProfiledVideoInput(bareProfile(), cfg(), 'reference-to-video', 'go', {
+            referenceImageUrls: ['a', 'b'],
+        });
+        expect(r2v.image_urls).toEqual(['a', 'b']);
+    });
+});
+
+describe('buildSeedanceVideoInput', () => {
+    it('passes "auto" through and strips the "s" suffix otherwise', () => {
+        expect(buildSeedanceVideoInput(cfg({ videoDuration: 'auto' }), 'text-to-video', 'go', noAssets).duration).toBe(
+            'auto',
+        );
+        expect(buildSeedanceVideoInput(cfg({ videoDuration: '8s' }), 'text-to-video', 'go', noAssets).duration).toBe(
+            '8',
+        );
+    });
+
+    it('always mirrors the audio toggle and sends seed only when set', () => {
+        const input = buildSeedanceVideoInput(cfg({ generateAudio: false }), 'text-to-video', 'go', noAssets);
+        expect(input.generate_audio).toBe(false);
+        expect(input).not.toHaveProperty('seed');
+    });
+});
+
+describe('buildLegacyVideoInput', () => {
+    it('clamps Grok duration to 1-15 and resolution to its enum', () => {
+        const input = buildLegacyVideoInput(
+            'xai/grok-imagine-video/text-to-video',
+            cfg({ videoDuration: '20s', videoResolution: '1080p' }),
+            'text-to-video',
+            'go',
+            noAssets,
+        );
+        expect(input.duration).toBe(15);
+        expect(input.resolution).toBe('720p');
+        expect(input).not.toHaveProperty('guidance_scale');
+    });
+
+    it('lets Grok edit-video fall back to auto resolution', () => {
+        const input = buildLegacyVideoInput(
+            'xai/grok-imagine-video/edit-video',
+            cfg({ videoResolution: '1080p' }),
+            'video-to-video',
+            'go',
+            { referenceImageUrls: [], videoUrl: 'v' },
+        );
+        expect(input.resolution).toBe('auto');
+        expect(input.video_url).toBe('v');
+    });
+
+    it('sends frame-based params instead of duration/resolution for LTX-2 19B', () => {
+        const input = buildLegacyVideoInput('fal-ai/ltx-2-19b', cfg(), 'text-to-video', 'go', noAssets);
+        expect(input).not.toHaveProperty('duration');
+        expect(input).not.toHaveProperty('resolution');
+        expect(input.num_frames).toBe(121);
+        expect(input.video_size).toBe('landscape_4_3');
+        expect(input.guidance_scale).toBeUndefined(); // videoGuidanceScale default 0
+    });
+
+    it('adds cfg_scale for Kling and generate_audio for Veo', () => {
+        expect(buildLegacyVideoInput('fal-ai/kling-video', cfg(), 'text-to-video', 'go', noAssets).cfg_scale).toBe(0.5);
+        expect(
+            buildLegacyVideoInput('fal-ai/veo3', cfg({ generateAudio: false }), 'text-to-video', 'go', noAssets)
+                .generate_audio,
+        ).toBe(false);
+    });
+
+    it('sends strength only for known v2v families in video-to-video mode', () => {
+        const wan = buildLegacyVideoInput('fal-ai/wan/video-to-video', cfg(), 'video-to-video', 'go', noAssets);
+        expect(wan.strength).toBe(0.8);
+        const other = buildLegacyVideoInput('fal-ai/pixverse/video-to-video', cfg(), 'video-to-video', 'go', noAssets);
+        expect(other).not.toHaveProperty('strength');
+    });
+});
+
+describe('buildVideoGenerationInput', () => {
+    it('dispatches extend mode to the extend builder even without a profile', () => {
+        const input = buildVideoGenerationInput({
+            modelId: 'some/unprofiled/extend-video',
+            mode: 'extend-video',
+            prompt: 'go',
+            config: cfg(),
+            assets: { referenceImageUrls: [], videoUrl: 'v' },
+        });
+        expect(input).toEqual({ prompt: 'go', video_url: 'v' });
+    });
+
+    it('dispatches profiled endpoints to the profile builder', () => {
+        const input = buildVideoGenerationInput({
+            modelId: 'bytedance/seedance-2.5/text-to-video',
+            mode: 'text-to-video',
+            prompt: 'go',
+            config: cfg({ videoDuration: '5' }),
+            assets: noAssets,
+        });
+        // Seedance 2.5 profile serializes duration as a string enum
+        expect(input.duration).toBe('5');
+    });
+});
+
+describe('extractVideoUrl', () => {
+    it('handles video as string, video as object, and videos array', () => {
+        expect(extractVideoUrl({ video: 'https://v' })).toBe('https://v');
+        expect(extractVideoUrl({ video: { url: 'https://v' } })).toBe('https://v');
+        expect(extractVideoUrl({ videos: ['https://v'] })).toBe('https://v');
+        expect(extractVideoUrl({ videos: [{ url: 'https://v' }] })).toBe('https://v');
+    });
+
+    it('returns undefined for empty or unrecognized shapes', () => {
+        expect(extractVideoUrl({})).toBeUndefined();
+        expect(extractVideoUrl({ videos: [] })).toBeUndefined();
+        expect(extractVideoUrl({ video: 42 })).toBeUndefined();
+    });
+});

--- a/src/services/videoInputBuilders.ts
+++ b/src/services/videoInputBuilders.ts
@@ -1,0 +1,468 @@
+/**
+ * Payload builders for video generation, mirroring `imageInputBuilders.ts`:
+ * pure functions of (config, profile, uploaded URLs) that return the input
+ * object for one endpoint family. The hook orchestrates (validate → upload →
+ * build → submit); everything about which fields an endpoint accepts lives
+ * here or in the capability profiles.
+ *
+ * Families, in dispatch order:
+ * - extend:   ExtendCapabilityProfile-driven (unprofiled = prompt + video_url)
+ * - profiled: VideoCapabilityProfile-driven (Seedance 2.5, MiniMax H3, LTX 2.x)
+ * - seedance: Seedance 2.0 legacy shape (a profile in disguise — fold into
+ *             capability profiles once its endpoint IDs are schema-verified)
+ * - legacy:   substring-detected models awaiting profile migration
+ */
+
+import type { GenerationMode } from '../components/GenerationTabs';
+import type { ConfigState } from '../config';
+import type { ExtendCapabilityProfile } from './extendVideoCapabilities';
+import { snapExtendDuration } from './extendVideoCapabilities';
+import {
+    activeLongDurationConstraint,
+    getVideoCapabilityProfile,
+    type VideoCapabilityProfile,
+} from './videoModelCapabilities';
+import { isSeedanceModel } from './videoModels';
+
+/** URLs of the media uploaded for the active mode; absent = not uploaded. */
+export interface VideoAssetUrls {
+    imageUrl?: string;
+    endImageUrl?: string;
+    referenceImageUrls: string[];
+    videoUrl?: string;
+}
+
+/**
+ * Check a generation request against the active mode's requirements.
+ * Returns a user-facing error message, or null when the request is valid.
+ */
+export function validateVideoRequest(args: {
+    mode: GenerationMode;
+    prompt: string;
+    extendProfile: ExtendCapabilityProfile | undefined;
+    imageCount: number;
+    hasVideo: boolean;
+}): string | null {
+    const { mode, prompt, extendProfile, imageCount, hasVideo } = args;
+
+    // Prompt is required everywhere except extend endpoints whose profile
+    // marks it optional (LTX 2.3 Pro extends without one).
+    const promptOptional = mode === 'extend-video' && extendProfile !== undefined && !extendProfile.promptRequired;
+    if (!prompt && !promptOptional) {
+        return 'Please enter a text prompt.';
+    }
+    if (mode === 'image-to-video' && imageCount === 0) {
+        return 'Please upload an image for image-to-video generation.';
+    }
+    if ((mode === 'video-to-video' || mode === 'extend-video') && !hasVideo) {
+        return 'Please upload a video to extend or transform.';
+    }
+    if (mode === 'reference-to-video' && imageCount === 0) {
+        return 'Please upload at least one reference image for reference-to-video generation.';
+    }
+    return null;
+}
+
+/**
+ * Extend endpoints: the source clip plus range/constraint parameters from the
+ * ExtendCapabilityProfile. Unprofiled extend endpoints get only prompt +
+ * video_url (server defaults apply).
+ */
+export function buildExtendVideoInput(
+    profile: ExtendCapabilityProfile | undefined,
+    config: ConfigState,
+    prompt: string,
+    videoUrl: string | undefined,
+): Record<string, unknown> {
+    const input: Record<string, unknown> = { video_url: videoUrl };
+
+    // LTX 2.3 Pro accepts requests without a prompt; omit the empty field.
+    if (prompt) {
+        input.prompt = prompt;
+    }
+
+    if (!profile) {
+        return input;
+    }
+
+    // Duration: FLUX defaults to "auto" and Veo has a single fixed length
+    // (min === max) — omit the field in both cases so the server default
+    // applies. LTX always takes explicit float seconds; whole-second
+    // endpoints get integers.
+    const durationAuto = profile.supportsAutoDuration && config.extendDurationAuto;
+    const durationFixed = profile.durationMin === profile.durationMax;
+    if (!durationAuto && !durationFixed) {
+        // Snap to the profile step so the payload matches what the panel
+        // displays (fractional carry-over from another model must not round
+        // differently here).
+        input.duration = snapExtendDuration(profile, config.extendDuration);
+    }
+
+    if (profile.supportsMode) {
+        input.mode = config.extendMode === 'start' ? 'start' : 'end';
+    }
+
+    // Context: omitting the field maximizes available context server-side.
+    if (profile.supportsContext && !config.extendContextAuto) {
+        input.context = Math.min(Math.max(config.extendContext, 1), 20);
+    }
+
+    if (profile.resolutions.length > 0) {
+        input.resolution = profile.resolutions.includes(config.videoResolution)
+            ? config.videoResolution
+            : profile.resolutions[0];
+    }
+
+    if (profile.aspectRatios.length > 0) {
+        input.aspect_ratio = profile.aspectRatios.includes(config.extendAspectRatio)
+            ? config.extendAspectRatio
+            : profile.aspectRatios[0];
+    }
+
+    if (profile.supportsGenerateAudio) {
+        input.generate_audio = config.generateAudio;
+    }
+
+    // Safety tolerance: clamp the stored level into the endpoint's range;
+    // FLUX takes an integer, Veo the digit as a string.
+    if (profile.safetyToleranceValues.length > 0) {
+        const values = profile.safetyToleranceValues;
+        const clamped = Math.min(Math.max(config.extendSafetyTolerance, values[0]), values[values.length - 1]);
+        input.safety_tolerance = profile.safetyToleranceFormat === 'string' ? String(clamped) : clamped;
+    }
+
+    if (profile.supportsNegativePrompt && config.videoNegativePrompt) {
+        input.negative_prompt = config.videoNegativePrompt;
+    }
+
+    if (profile.supportsSeed && config.videoSeed !== null) {
+        input.seed = config.videoSeed;
+    }
+
+    // auto_fix defaults to false server-side; only send when enabled.
+    if (profile.supportsAutoFix && config.extendAutoFix) {
+        input.auto_fix = true;
+    }
+
+    return input;
+}
+
+/**
+ * Profiled endpoints (Seedance 2.5, MiniMax H3, LTX 2.x): the profile
+ * declares which fields the endpoint's schema accepts, so the payload is
+ * built from data instead of per-model conditionals.
+ */
+export function buildProfiledVideoInput(
+    profile: VideoCapabilityProfile,
+    config: ConfigState,
+    mode: GenerationMode,
+    prompt: string,
+    assets: VideoAssetUrls,
+): Record<string, unknown> {
+    const input: Record<string, unknown> = { prompt };
+
+    if (config.videoResolution) {
+        input.resolution = config.videoResolution;
+    }
+
+    // Duration comes from the profile's enum. Storage may hold a legacy
+    // "5s" suffix from other models; strip it before serializing.
+    if (config.videoDuration) {
+        const raw = config.videoDuration.trim().replace(/s$/, '');
+        if (profile.durationFormat === 'integer') {
+            const seconds = parseInt(raw, 10);
+            if (!Number.isNaN(seconds)) {
+                input.duration = seconds;
+            }
+        } else {
+            input.duration = raw;
+        }
+    }
+
+    // Aspect ratio: omitted entirely when the schema has no such input
+    // (empty enum); a profile may pin it (Seedance 2.5 i2v only accepts "auto").
+    if (profile.forcedAspectRatio) {
+        input.aspect_ratio = profile.forcedAspectRatio;
+    } else if (profile.aspectRatios.length > 0 && config.videoAspectRatio) {
+        input.aspect_ratio = config.videoAspectRatio;
+    }
+
+    // FPS: integer field, only on endpoints whose schema declares an enum (LTX).
+    if (profile.fpsValues.length > 0 && config.videoFps) {
+        const fps = parseInt(config.videoFps, 10);
+        if (!Number.isNaN(fps)) {
+            input.fps = fps;
+        }
+    }
+
+    // Long durations can pin fps/resolution (LTX 2.3 Fast: 12s+ only runs at
+    // 25 fps, 1080p). The UI collapses the selectors too, but normalize here
+    // so a stale stored combination can't reach the API.
+    const durationConstraint = activeLongDurationConstraint(profile, config.videoDuration);
+    if (durationConstraint) {
+        input.resolution = durationConstraint.resolution;
+        if (profile.fpsValues.length > 0) {
+            input.fps = parseInt(durationConstraint.fps, 10);
+        }
+    }
+
+    // camera_motion is optional server-side; 'none' means omit it.
+    if (profile.cameraMotions.length > 0 && config.videoCameraMotion !== 'none') {
+        input.camera_motion = config.videoCameraMotion;
+    }
+
+    if (profile.supportsGenerateAudio) {
+        input.generate_audio = config.generateAudio;
+    }
+    if (profile.supportsSeed && config.videoSeed !== null) {
+        input.seed = config.videoSeed;
+    }
+    if (profile.supportsNegativePrompt && config.videoNegativePrompt) {
+        input.negative_prompt = config.videoNegativePrompt;
+    }
+    if (profile.supportsPromptExpansion) {
+        input.enable_prompt_expansion = config.videoEnablePromptExpansion;
+    }
+    if (profile.supportsSafetyChecker) {
+        input.enable_safety_checker = config.enableSafetyChecker;
+    }
+
+    applyImageInputs(input, mode, assets);
+
+    return input;
+}
+
+/**
+ * Seedance 2.0: its own input shape (string `duration` enum, no cfg_scale,
+ * no guidance_scale, no fps). Structurally a capability profile in disguise —
+ * scheduled to fold into `PROFILES` once its endpoint IDs are enumerated and
+ * schema-verified; until then it stays quarantined here.
+ */
+export function buildSeedanceVideoInput(
+    config: ConfigState,
+    mode: GenerationMode,
+    prompt: string,
+    assets: VideoAssetUrls,
+): Record<string, unknown> {
+    const input: Record<string, unknown> = { prompt };
+
+    // Resolution (Pro: 480p/720p/1080p; Fast: 480p/720p)
+    if (config.videoResolution) {
+        input.resolution = config.videoResolution;
+    }
+
+    // Duration: seedance expects "auto" or a string "4".."15".
+    // Storage may have either a bare number ("5") or a legacy "5s" suffix.
+    if (config.videoDuration) {
+        const raw = config.videoDuration.trim();
+        input.duration = raw === 'auto' ? 'auto' : raw.replace(/s$/, '');
+    }
+
+    // Aspect ratio: pass through, including "auto" and "21:9".
+    if (config.videoAspectRatio) {
+        input.aspect_ratio = config.videoAspectRatio;
+    }
+
+    // Synchronized audio (default true on the API; we mirror the user's toggle).
+    input.generate_audio = config.generateAudio;
+
+    // Seed (optional integer).
+    if (config.videoSeed !== null) {
+        input.seed = config.videoSeed;
+    }
+
+    applyImageInputs(input, mode, assets);
+
+    return input;
+}
+
+/** Mode-specific image inputs (start frame + optional end frame, or references). */
+function applyImageInputs(input: Record<string, unknown>, mode: GenerationMode, assets: VideoAssetUrls): void {
+    if (mode === 'image-to-video' && assets.imageUrl) {
+        input.image_url = assets.imageUrl;
+        if (assets.endImageUrl) {
+            input.end_image_url = assets.endImageUrl;
+        }
+    } else if (mode === 'reference-to-video' && assets.referenceImageUrls.length > 0) {
+        input.image_urls = assets.referenceImageUrls;
+    }
+}
+
+/**
+ * Legacy parameter routing for unprofiled models (Kling, Veo t2v, legacy
+ * LTX-2 tiers, Grok, MMAudio, Bria, Wan/Hunyuan/AnimateDiff v2v). This is the
+ * migration quarantine: new model families should get a capability profile
+ * instead of another substring branch here. Fields are only ever added —
+ * duration/resolution are decided per family up front, never set generically
+ * and patched after.
+ */
+export function buildLegacyVideoInput(
+    modelId: string,
+    config: ConfigState,
+    mode: GenerationMode,
+    prompt: string,
+    assets: VideoAssetUrls,
+): Record<string, unknown> {
+    const input: Record<string, unknown> = { prompt };
+
+    const modelIdLower = modelId.toLowerCase();
+    const isKlingModel = modelIdLower.includes('kling');
+    const isVeoModel = modelIdLower.includes('veo');
+    const isLtx19bModel = modelIdLower.includes('ltx-2-19b');
+    const isLtxProFastModel = modelIdLower.includes('ltx-2') && !isLtx19bModel;
+    const isGrokVideoModel = modelIdLower.includes('grok-imagine-video');
+    const isGrokVideoEdit = isGrokVideoModel && modelIdLower.includes('edit-video');
+    const supportsAudio = isVeoModel || isLtx19bModel || isLtxProFastModel;
+    const supportsGuidanceScale =
+        isLtx19bModel || (!isVeoModel && !isLtxProFastModel && !isKlingModel && !isGrokVideoModel);
+
+    // V2V model detection
+    const isVideoToVideo = mode === 'video-to-video';
+    const isMMAudioModel = modelIdLower.includes('mmaudio');
+    const isBriaBgRemoval = modelIdLower.includes('bria') && modelIdLower.includes('background-removal');
+    const isLtx19bV2V = isLtx19bModel && modelIdLower.includes('video-to-video');
+    const isWanV2V = modelIdLower.includes('wan') && modelIdLower.includes('video-to-video');
+    const isHunyuanV2V = modelIdLower.includes('hunyuan') && modelIdLower.includes('video-to-video');
+    const isAnimateDiffV2V = modelIdLower.includes('animatediff') && modelIdLower.includes('video-to-video');
+
+    if (mode === 'image-to-video' && assets.imageUrl) {
+        input.image_url = assets.imageUrl;
+    }
+    if (isVideoToVideo && assets.videoUrl) {
+        input.video_url = assets.videoUrl;
+    }
+
+    // Duration/resolution per family: LTX-2 19B takes neither (frame-based),
+    // Grok clamps duration to 1-15s and resolution to its enum, everything
+    // else passes the stored values through.
+    if (!isLtx19bModel) {
+        if (config.videoDuration) {
+            const durationNum = parseInt(config.videoDuration.replace('s', ''), 10);
+            input.duration = isGrokVideoModel
+                ? Math.min(15, Math.max(1, durationNum))
+                : durationNum || config.videoDuration;
+        }
+        if (config.videoResolution) {
+            if (isGrokVideoModel) {
+                // Text/image to video only supports 480p/720p; edit-video also takes 'auto'.
+                const res = config.videoResolution;
+                input.resolution = res === '480p' || res === '720p' ? res : isGrokVideoEdit ? 'auto' : '720p';
+            } else {
+                input.resolution = config.videoResolution;
+            }
+        }
+    }
+
+    if (config.videoAspectRatio) {
+        input.aspect_ratio = config.videoAspectRatio;
+    }
+
+    // CFG scale for Kling models (0-1 range)
+    if (isKlingModel) {
+        input.cfg_scale = config.videoCfgScale;
+    }
+
+    // Guidance scale only for models that support it
+    if (supportsGuidanceScale && config.videoGuidanceScale > 0) {
+        input.guidance_scale = config.videoGuidanceScale;
+    }
+
+    // generate_audio for veo and ltx-2 models
+    if (supportsAudio) {
+        input.generate_audio = config.generateAudio;
+    }
+
+    // fps for LTX-2 Pro/Fast models
+    if (isLtxProFastModel) {
+        input.fps = parseInt(config.videoFps, 10);
+    }
+
+    // LTX-2 19B specific parameters
+    if (isLtx19bModel) {
+        input.num_frames = config.videoNumFrames;
+        input.video_size = config.videoOutputSize;
+        input.use_multiscale = config.videoUseMultiscale;
+        input.num_inference_steps = config.videoNumInferenceSteps;
+        input.acceleration = config.videoAcceleration;
+        input.enable_prompt_expansion = config.videoEnablePromptExpansion;
+
+        // Camera LoRA only if not 'none'
+        if (config.videoCameraLora !== 'none') {
+            input.camera_lora = config.videoCameraLora;
+            input.camera_lora_scale = config.videoCameraLoraScale;
+        }
+    }
+
+    if (config.videoSeed !== null) {
+        input.seed = config.videoSeed;
+    }
+
+    if (config.videoNegativePrompt) {
+        input.negative_prompt = config.videoNegativePrompt;
+    }
+
+    // Video strength for V2V transformation
+    if (isVideoToVideo && (isLtx19bV2V || isWanV2V || isHunyuanV2V || isAnimateDiffV2V)) {
+        input.strength = config.videoStrength;
+    }
+
+    // Preprocessor for LTX-2 19B V2V
+    if (isLtx19bV2V && config.videoPreprocessor !== 'none') {
+        input.preprocessor = config.videoPreprocessor;
+    }
+
+    // MMAudio V2 parameters
+    if (isMMAudioModel) {
+        input.cfg_strength = config.mmAudioCfgStrength;
+        input.num_steps = config.mmAudioNumSteps;
+    }
+
+    // Bria Background Removal parameters
+    if (isBriaBgRemoval) {
+        input.background_color = config.briaBgColor;
+        input.output_container_and_codec = config.briaOutputCodec;
+    }
+
+    return input;
+}
+
+/** Build the generation payload for any video endpoint, dispatching by family. */
+export function buildVideoGenerationInput(args: {
+    modelId: string;
+    mode: GenerationMode;
+    prompt: string;
+    config: ConfigState;
+    assets: VideoAssetUrls;
+    extendProfile?: ExtendCapabilityProfile;
+}): Record<string, unknown> {
+    const { modelId, mode, prompt, config, assets, extendProfile } = args;
+
+    if (mode === 'extend-video') {
+        return buildExtendVideoInput(extendProfile, config, prompt, assets.videoUrl);
+    }
+
+    const profile = getVideoCapabilityProfile(modelId);
+    if (profile) {
+        return buildProfiledVideoInput(profile, config, mode, prompt, assets);
+    }
+    if (isSeedanceModel(modelId)) {
+        return buildSeedanceVideoInput(config, mode, prompt, assets);
+    }
+    return buildLegacyVideoInput(modelId, config, mode, prompt, assets);
+}
+
+/**
+ * Pull the video URL out of a fal queue result. The response is either
+ * `video` (a URL string or `{ url }` object) or a non-empty `videos` array
+ * of the same shapes.
+ */
+export function extractVideoUrl(data: Record<string, unknown>): string | undefined {
+    const candidate = data.video || (Array.isArray(data.videos) && data.videos.length > 0 ? data.videos[0] : undefined);
+    if (typeof candidate === 'string') {
+        return candidate;
+    }
+    if (candidate && typeof candidate === 'object') {
+        return (candidate as { url?: string }).url;
+    }
+    return undefined;
+}

--- a/src/utils/videoMetadata.ts
+++ b/src/utils/videoMetadata.ts
@@ -32,7 +32,16 @@ function captureFrame(video: HTMLVideoElement): string | null {
     }
 }
 
-export function probeVideoFile(file: File): Promise<VideoFileMetadata> {
+export interface ProbeVideoOptions {
+    /**
+     * Skip the canvas poster capture (the expensive part of the probe) when
+     * only duration/dimensions are needed, e.g. pre-upload validation.
+     */
+    capturePoster?: boolean;
+}
+
+export function probeVideoFile(file: File, options: ProbeVideoOptions = {}): Promise<VideoFileMetadata> {
+    const capturePoster = options.capturePoster !== false;
     return new Promise((resolve, reject) => {
         const objectUrl = URL.createObjectURL(file);
         const video = document.createElement('video');
@@ -56,7 +65,7 @@ export function probeVideoFile(file: File): Promise<VideoFileMetadata> {
                 // Re-read after seeking: Chrome reports Infinity for
                 // MediaRecorder-produced webm until forced past the end.
                 const duration = video.duration;
-                const posterUrl = captureFrame(video);
+                const posterUrl = capturePoster ? captureFrame(video) : null;
                 cleanup();
                 if (!Number.isFinite(duration) || duration <= 0) {
                     reject(new Error('Could not determine the video duration.'));


### PR DESCRIPTION
The ~580-line generateVideo callback becomes a thin orchestrator
(validate → probe → upload → build → submit → extract); the payload
rules move to services, mirroring how imageInputBuilders.ts already
isolates the image-side equivalents:

- services/videoInputBuilders.ts: buildExtendVideoInput /
  buildProfiledVideoInput / buildSeedanceVideoInput /
  buildLegacyVideoInput behind a buildVideoGenerationInput dispatcher,
  plus validateVideoRequest and extractVideoUrl — all pure and now
  covered by 26 unit tests. The legacy builder is additive (no more
  set-then-delete/overwrite: LTX-19B never receives duration/resolution,
  Grok's clamps are computed once) and the dead Grok
  `delete input.guidance_scale` is removed (supportsGuidanceScale
  already excludes Grok).
- services/extendVideoCapabilities.ts: describeExtendSourceViolation
  puts the violation wording next to checkExtendSource so the hook and
  the UI chips can't disagree.
- services/falStorage.ts: shared parallel fal.storage upload helper;
  the three near-identical upload try/catch blocks collapse into one
  uploadVideoAssets, and the start/end-frame pair now uploads in
  parallel instead of sequentially.
- utils/videoMetadata.ts: probeVideoFile gains { capturePoster: false }
  so the pre-upload extend validation skips the canvas/JPEG poster
  encode it never used.

Payload output is byte-identical for every endpoint family; only the
upload status copy for the two-frame case changed ("Uploading images").

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>