### PR TITLE
fix(video): serialize LTX 2.3 duration as integer

### DIFF
--- a/src/services/videoInputBuilders.test.ts
+++ b/src/services/videoInputBuilders.test.ts
@@ -313,6 +313,23 @@ describe('Seedance 2.0 via the profile builder', () => {
     });
 });
 
+describe('LTX 2.3 via the profile builder', () => {
+    it.each([
+        ['fal-ai/ltx-2.3/image-to-video', '8', 8],
+        ['fal-ai/ltx-2.3/image-to-video/fast', '20', 20],
+    ])('serializes %s duration as an integer', (modelId, storedDuration, expectedDuration) => {
+        const input = buildVideoGenerationInput({
+            modelId,
+            mode: 'image-to-video',
+            prompt: 'go',
+            config: cfg({ videoDuration: storedDuration, videoResolution: '1080p' }),
+            assets: { imageUrl: 'start', referenceImageUrls: [] },
+        });
+
+        expect(input.duration).toBe(expectedDuration);
+    });
+});
+
 describe('buildLegacyVideoInput', () => {
     it('clamps Grok duration to 1-15 and resolution to its enum', () => {
         const input = buildLegacyVideoInput(

--- a/src/services/videoModelCapabilities.test.ts
+++ b/src/services/videoModelCapabilities.test.ts
@@ -157,8 +157,8 @@ describe('getVideoCapabilityProfile', () => {
             const profile = getVideoCapabilityProfile(endpointId);
             expect(profile).toBeDefined();
 
-            // No "auto" duration — string enum defaulting to "6"
-            expect(profile?.durationFormat).toBe('string');
+            // No "auto" duration — integer enum defaulting to 6
+            expect(profile?.durationFormat).toBe('integer');
             expect(profile?.durations[0]).toBe('6');
             expect(profile?.durations).not.toContain('auto');
 

--- a/src/services/videoModelCapabilities.ts
+++ b/src/services/videoModelCapabilities.ts
@@ -196,7 +196,8 @@ const LTX_25_FAST_DURATIONS = ['auto', '6', '8', '10', '12', '14', '16', '18', '
 const LTX_25_FAST_RESOLUTIONS = ['1080p', '720p', '1440p', '2160p'];
 
 /**
- * Shared LTX 2.3 schema (fal-ai/ltx-2.3): no "auto" duration (default "6"),
+ * Shared LTX 2.3 schema (fal-ai/ltx-2.3): integer duration with no "auto"
+ * option (default 6),
  * resolutions start at 1080p (no 720p), no camera_motion, no seed. Fast tier
  * extends durations to 20s, but 12s+ requires 25 fps at 1080p (server-side
  * constraint the schema documents in prose only).
@@ -204,7 +205,7 @@ const LTX_25_FAST_RESOLUTIONS = ['1080p', '720p', '1440p', '2160p'];
 function ltx23Profile(overrides: Partial<VideoCapabilityProfile>): VideoCapabilityProfile {
     return {
         durations: ['6', '8', '10'],
-        durationFormat: 'string',
+        durationFormat: 'integer',
         resolutions: ['1080p', '1440p', '2160p'],
         aspectRatios: ['16:9', '9:16'],
         fpsValues: ['25', '24', '48', '50'],


### PR DESCRIPTION
Match the strict fal.ai integer enum for standard and Fast endpoints
while preserving LTX 2.5's mixed duration handling.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>